### PR TITLE
Add mESI middleware setup for FrankenPHP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ go.work.sum
 /debian/go-mesi/
 /debian/libgomesi/
 /debian/libgomesi-dev/
+/servers/frankenphp/frankenphp

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ we can download this code fragment using FetchAPI or htmlx
 - [x] PHP extension - See [Installation and configuration](php-ext/README.md)
 - [x] Plugin for Nginx - See [Installation and configuration](servers/nginx/README.md)
 - [x] Plugin for Caddy - See [Installation and configuration](servers/caddy/README.md)
+- [x] Plugin for FrankenPHP - See [Installation and configuration](servers/frankenphp/README.md)
 - [x] CLI - for testing
-- [ ] Plugin for FrankenPHP
 - [ ] Plugin for Apache (if possible)
 - [ ] Standalone proxy server - for testing
 

--- a/servers/frankenphp/Caddyfile
+++ b/servers/frankenphp/Caddyfile
@@ -1,0 +1,10 @@
+{
+    admin off
+    order mesi before file_server
+}
+
+:8080 {
+    root * ../../examples
+    mesi
+    file_server
+}

--- a/servers/frankenphp/Makefile
+++ b/servers/frankenphp/Makefile
@@ -1,0 +1,12 @@
+build:
+	CGO_ENABLED=1 \
+	XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx,nowatcher" \
+	CGO_CFLAGS=$$(php-config --includes) \
+	CGO_LDFLAGS="$$(php-config --ldflags) $$(php-config --libs)" \
+	xcaddy build \
+		--output frankenphp \
+		--with github.com/dunglas/frankenphp \
+		--with github.com/crazy-goat/go-mesi/servers/caddy=../caddy
+
+run: build
+	./frankenphp run --config Caddyfile

--- a/servers/frankenphp/README.md
+++ b/servers/frankenphp/README.md
@@ -1,0 +1,56 @@
+# ESI middleware for FrankenPHP
+A lightweight implementation of Edge Side Includes (ESI) middleware for FrankenPHP server
+
+## Building FrankenPHP with mESI middleware
+To add the mesi middleware to the FrankenPHP server, you need to compile it properly. 
+The best way to do this is to use the [xcaddy compiler](https://github.com/caddyserver/xcaddy)
+
+```shell
+go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+```
+
+Then just run the command below
+```shell
+CGO_ENABLED=1 \
+XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx,nowatcher" \
+CGO_CFLAGS=$$(php-config --includes) \
+CGO_LDFLAGS="$$(php-config --ldflags) $$(php-config --libs)" \
+xcaddy build \
+    --output frankenphp \
+    --with github.com/dunglas/frankenphp \
+    --with github.com/crazy-goat/go-mesi/servers/caddy=../caddy
+```
+
+Then we can check if caddy contains the right module using this command
+
+```shell
+frankenphp list-modules | grep mesi
+```
+
+this command should return 
+
+```
+http.handlers.mesi
+```
+
+## Configuration
+Then you need to disable the mESSI middleware for that server.
+You also need to set the appropriate order of the handlers using the order directive.
+
+```
+{
+    order mesi before file_server
+}
+
+:8080 {
+    root * ../../examples
+    mesi
+    file_server
+}
+```
+
+Finally, you can start the FrankenPHP server with the command:
+
+```shell
+frankenphp run --config Caddyfile
+```


### PR DESCRIPTION
Introduce configuration files, a README, and a Makefile to integrate mESI middleware into the FrankenPHP server. This includes build instructions using xcaddy, server configuration via a Caddyfile, and basic usage guidance. Update .gitignore to exclude the FrankenPHP build artifact.