### PR TITLE
Add SSRF protection for ESI include fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - **Concurrent fetch** - You need ultra performance - set `fetch-mode="concurrent"` to always fetch content from the fastest source.
 - **esi:include timeout** - Timeout can be set both globally and specifically for a selected `esi:include` tag. In combination with fallback content, you can easily manage the page generation time.
 - **Fallback content** - Set the content to be displayed if remote content download fails.
+- **SSRF Protection** – Built-in protection against Server-Side Request Forgery attacks with private IP blocking and optional host whitelisting.
 ## ESI Parser Configuration
 This document describes the configuration structure for the mESI parser.
 
@@ -24,10 +25,12 @@ The parser configuration is defined using the following structure:
 
 ```go
 type EsiParserConfig struct {
-  DefaultUrl    string
-  MaxDepth      uint
-  Timeout       time.Duration
-  ParseOnHeader bool
+  DefaultUrl     string
+  MaxDepth       uint
+  Timeout        time.Duration
+  ParseOnHeader  bool
+  AllowedHosts   []string
+  BlockPrivateIPs bool
 }
 ```
 ### Configuration Parameters
@@ -60,6 +63,22 @@ _NOTE:_
 **ParseOnHeader**
 
 If set to true, then server responses will process ESI tags only when the response contains the `Edge-control: dca=esi` header
+
+**BlockPrivateIPs**
+
+Protects against Server-Side Request Forgery (SSRF) attacks by blocking requests to private and reserved IP addresses. When enabled (default: `true`), the parser will reject ESI includes that resolve to:
+
+- Private networks: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+- Loopback: `127.0.0.0/8`, `localhost`
+- Link-local: `169.254.0.0/16`
+- Unspecified: `0.0.0.0`
+- Multicast: `224.0.0.0/4`, `240.0.0.0/4`
+
+**AllowedHosts**
+
+When set, specifies a whitelist of allowed hostnames for ESI includes. If defined, only requests to matching hosts will be allowed. Supports exact matches and subdomain matching (e.g., `example.com` matches `www.example.com`).
+
+This is useful when you want to restrict ESI includes to a specific set of trusted domains while still blocking private IP ranges.
 
 **fetch-mode** - `esi:include` tag only
 

--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -3,7 +3,9 @@ package mesi
 import (
 	"errors"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -14,15 +16,83 @@ func IsEsiResponse(response *http.Response) bool {
 	return strings.Contains(header, "dca=esi")
 }
 
-func singleFetchUrl(url string, config EsiParserConfig) (data string, esiResponse bool, err error) {
+func isURLSafe(requestedURL string, config EsiParserConfig) error {
+	if config.BlockPrivateIPs {
+		parsedURL, err := url.Parse(requestedURL)
+		if err != nil {
+			return errors.New("invalid url: " + err.Error())
+		}
+
+		host := parsedURL.Host
+		if host == "" {
+			return errors.New("url has no host")
+		}
+
+		if config.AllowedHosts != nil && len(config.AllowedHosts) > 0 {
+			allowed := false
+			for _, allowedHost := range config.AllowedHosts {
+				if host == allowedHost || strings.HasSuffix(host, "."+allowedHost) {
+					allowed = true
+					break
+				}
+			}
+			if !allowed {
+				return errors.New("host not in allowed list: " + host)
+			}
+			return nil
+		}
+
+		ips, err := net.LookupIP(host)
+		if err != nil {
+			return errors.New("cannot resolve host: " + err.Error())
+		}
+
+		for _, ip := range ips {
+			if isPrivateOrReservedIP(ip) {
+				return errors.New("url resolves to private/reserved ip: " + ip.String())
+			}
+		}
+	}
+
+	return nil
+}
+
+func isPrivateOrReservedIP(ip net.IP) bool {
+	privateBlocks := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"127.0.0.0/8",
+		"169.254.0.0/16",
+		"0.0.0.0/8",
+		"224.0.0.0/4",
+		"240.0.0.0/4",
+	}
+
+	for _, block := range privateBlocks {
+		_, cidr, _ := net.ParseCIDR(block)
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+
+	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsUnspecified()
+}
+
+func singleFetchUrl(requestedURL string, config EsiParserConfig) (data string, esiResponse bool, err error) {
 	if config.Timeout <= 0 {
 		return "", false, errors.New("exceeded time budget")
+	}
+
+	if err := isURLSafe(requestedURL, config); err != nil {
+		return "", false, errors.New("ssrf validation failed: " + err.Error())
 	}
 
 	client := http.Client{
 		Timeout: config.Timeout,
 	}
 
+	url := requestedURL
 	if !strings.HasPrefix(url, "http") && !strings.HasPrefix(url, "https") {
 		if config.DefaultUrl == "" {
 			return "", false, errors.New("default url can't be empty, on relative urls: " + url)
@@ -30,7 +100,10 @@ func singleFetchUrl(url string, config EsiParserConfig) (data string, esiRespons
 		url = strings.TrimRight(config.DefaultUrl, "/") + "/" + strings.TrimLeft(url, "/")
 	}
 
-	req, _ := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", false, errors.New("failed to create request: " + err.Error())
+	}
 	req.Header.Set("Surrogate-Capability", "ESI/1.0")
 
 	content, err := client.Do(req)

--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -14,18 +14,21 @@ type Response struct {
 }
 
 type EsiParserConfig struct {
-	DefaultUrl    string
-	MaxDepth      uint
-	Timeout       time.Duration
-	ParseOnHeader bool
+	DefaultUrl      string
+	MaxDepth        uint
+	Timeout         time.Duration
+	ParseOnHeader   bool
+	AllowedHosts    []string
+	BlockPrivateIPs bool
 }
 
 func CreateDefaultConfig() EsiParserConfig {
 	return EsiParserConfig{
-		DefaultUrl:    "http://127.0.0.1/",
-		MaxDepth:      5,
-		Timeout:       10 * time.Second,
-		ParseOnHeader: false,
+		DefaultUrl:      "http://127.0.0.1/",
+		MaxDepth:        5,
+		Timeout:         10 * time.Second,
+		ParseOnHeader:   false,
+		BlockPrivateIPs: true,
 	}
 }
 
@@ -84,9 +87,10 @@ func (c EsiParserConfig) OverrideConfig(token esiIncludeToken) EsiParserConfig {
 // Deprecated: FunctionName is deprecated, please use mEsiParse
 func Parse(input string, maxDepth int, defaultUrl string) string {
 	config := EsiParserConfig{
-		DefaultUrl: defaultUrl,
-		MaxDepth:   uint(maxDepth),
-		Timeout:    10 * time.Second, // default value 5 sec
+		DefaultUrl:      defaultUrl,
+		MaxDepth:        uint(maxDepth),
+		Timeout:         10 * time.Second,
+		BlockPrivateIPs: true,
 	}
 
 	return MESIParse(input, config)


### PR DESCRIPTION
## Summary
- Block ESI includes to private/reserved IP addresses (10.x, 172.16-31.x, 192.168.x, 127.x, 169.254.x, 0.0.0.0, multicast)
- Add `AllowedHosts` whitelist option for restricting ESI includes to specific domains
- Fix ignored error from `http.NewRequest` in `singleFetchUrl`

## Changes

### mesi/fetchUrl.go
- Added `isURLSafe()` function for URL validation
- Added `isPrivateOrReservedIP()` function for IP range checking
- SSRF validation runs before any HTTP request

### mesi/parser.go
- Added `AllowedHosts []string` to `EsiParserConfig`
- Added `BlockPrivateIPs bool` to `EsiParserConfig` (default: true)
- Updated `CreateDefaultConfig()` and deprecated `Parse()` to use new defaults

### README.md
- Documented new `BlockPrivateIPs` and `AllowedHosts` config options
- Added SSRF Protection to features list

## Breaking changes
None - new fields have safe defaults.

## Related issues
Fixes #17