### PR TITLE
Fix URL scheme validation to prevent bypass

### DIFF
--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -84,6 +84,15 @@ func singleFetchUrl(requestedURL string, config EsiParserConfig) (data string, e
 		return "", false, errors.New("exceeded time budget")
 	}
 
+	parsed, err := url.Parse(requestedURL)
+	if err != nil {
+		return "", false, errors.New("invalid url: " + err.Error())
+	}
+
+	if parsed.Scheme != "" && parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", false, errors.New("invalid url scheme: " + parsed.Scheme)
+	}
+
 	if err := isURLSafe(requestedURL, config); err != nil {
 		return "", false, errors.New("ssrf validation failed: " + err.Error())
 	}
@@ -92,19 +101,12 @@ func singleFetchUrl(requestedURL string, config EsiParserConfig) (data string, e
 		Timeout: config.Timeout,
 	}
 
-	parsed, err := url.Parse(requestedURL)
-	if err != nil {
-		return "", false, errors.New("invalid url: " + err.Error())
-	}
-
 	var urlToFetch string
 	if parsed.Scheme == "" {
 		if config.DefaultUrl == "" {
 			return "", false, errors.New("default url can't be empty, on relative urls: " + requestedURL)
 		}
 		urlToFetch = strings.TrimRight(config.DefaultUrl, "/") + "/" + strings.TrimLeft(requestedURL, "/")
-	} else if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return "", false, errors.New("invalid url scheme: " + parsed.Scheme)
 	} else {
 		urlToFetch = requestedURL
 	}

--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -92,15 +92,24 @@ func singleFetchUrl(requestedURL string, config EsiParserConfig) (data string, e
 		Timeout: config.Timeout,
 	}
 
-	url := requestedURL
-	if !strings.HasPrefix(url, "http") && !strings.HasPrefix(url, "https") {
-		if config.DefaultUrl == "" {
-			return "", false, errors.New("default url can't be empty, on relative urls: " + url)
-		}
-		url = strings.TrimRight(config.DefaultUrl, "/") + "/" + strings.TrimLeft(url, "/")
+	parsed, err := url.Parse(requestedURL)
+	if err != nil {
+		return "", false, errors.New("invalid url: " + err.Error())
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	var urlToFetch string
+	if parsed.Scheme == "" {
+		if config.DefaultUrl == "" {
+			return "", false, errors.New("default url can't be empty, on relative urls: " + requestedURL)
+		}
+		urlToFetch = strings.TrimRight(config.DefaultUrl, "/") + "/" + strings.TrimLeft(requestedURL, "/")
+	} else if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", false, errors.New("invalid url scheme: " + parsed.Scheme)
+	} else {
+		urlToFetch = requestedURL
+	}
+
+	req, err := http.NewRequest("GET", urlToFetch, nil)
 	if err != nil {
 		return "", false, errors.New("failed to create request: " + err.Error())
 	}

--- a/mesi/fetchUrl_test.go
+++ b/mesi/fetchUrl_test.go
@@ -1,104 +1,189 @@
 package mesi
 
 import (
-	"net/url"
-	"strings"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 )
 
-func TestUrlSchemeValidation(t *testing.T) {
-	validSchemes := []string{"http", "https"}
-	invalidSchemes := []string{"httpx", "httpfoo", "httpss", "ftp", "file", "javascript", "data", "gopher"}
-
-	baseHost := "://example.com/path"
-
-	for _, scheme := range validSchemes {
-		u := scheme + baseHost
-		parsed, err := url.Parse(u)
-		if err != nil {
-			t.Errorf("valid scheme %q failed to parse: %v", scheme, err)
-			continue
-		}
-		if parsed.Scheme != scheme {
-			t.Errorf("expected scheme %q, got %q", scheme, parsed.Scheme)
-		}
-	}
-
-	for _, scheme := range invalidSchemes {
-		u := scheme + baseHost
-		parsed, err := url.Parse(u)
-		if err != nil {
-			t.Errorf("invalid scheme %q failed to parse: %v", scheme, err)
-			continue
-		}
-		if parsed.Scheme == "http" || parsed.Scheme == "https" {
-			t.Errorf("scheme %q should be rejected but got scheme %q", scheme, parsed.Scheme)
-		}
-	}
-}
-
-func TestRelativeUrlHandling(t *testing.T) {
+func TestSingleFetchUrlSchemeValidation(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		defUrl   string
-		expected string
+		name      string
+		url       string
+		wantErr   bool
+		errSubstr string
 	}{
-		{"simple relative", "foo/bar", "http://base.com/", "http://base.com/foo/bar"},
-		{"absolute path", "/foo/bar", "http://base.com/", "http://base.com/foo/bar"},
-		{"no leading slash", "foo/bar", "http://base.com", "http://base.com/foo/bar"},
+		{"http scheme valid", "http://example.com", false, ""},
+		{"https scheme valid", "https://example.com", false, ""},
+		{"httpx scheme invalid", "httpx://example.com", true, "invalid url scheme"},
+		{"httpfoo scheme invalid", "httpfoo://example.com", true, "invalid url scheme"},
+		{"httpss scheme invalid", "httpss://example.com", true, "invalid url scheme"},
+		{"ftp scheme invalid", "ftp://example.com", true, "invalid url scheme"},
+		{"file scheme invalid", "file:///etc/passwd", true, "invalid url scheme"},
+		{"javascript scheme invalid", "javascript:alert(1)", true, "invalid url scheme"},
+	}
+
+	config := EsiParserConfig{
+		DefaultUrl:      "http://127.0.0.1/",
+		MaxDepth:        1,
+		Timeout:         1 * time.Second,
+		BlockPrivateIPs: false,
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parsed, _ := url.Parse(tt.input)
-			if parsed.Scheme != "" {
-				t.Errorf("relative URL %q should have empty scheme, got %q", tt.input, parsed.Scheme)
-			}
-
-			result := strings.TrimRight(tt.defUrl, "/") + "/" + strings.TrimLeft(tt.input, "/")
-			if result != tt.expected {
-				t.Errorf("expected %q, got %q", tt.expected, result)
+			_, _, err := singleFetchUrl(tt.url, config)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errSubstr)
+				} else if tt.errSubstr != "" && !contains(err.Error(), tt.errSubstr) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errSubstr)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
 			}
 		})
 	}
 }
 
-func TestUrlSchemeCheckLogic(t *testing.T) {
-	cases := []struct {
-		url     string
-		wantErr bool
-		errMsg  string
-	}{
-		{"http://example.com", false, ""},
-		{"https://example.com", false, ""},
-		{"http://example.com/path?query=1", false, ""},
-		{"https://example.com/path#anchor", false, ""},
-		{"httpx://example.com", true, "invalid url scheme"},
-		{"httpfoo://example.com", true, "invalid url scheme"},
-		{"httpss://example.com", true, "invalid url scheme"},
-		{"ftp://example.com", true, "invalid url scheme"},
-		{"file:///etc/passwd", true, "invalid url scheme"},
-		{"javascript:alert(1)", true, "invalid url scheme"},
+func TestSingleFetchUrlRelativeUrl(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(r.URL.Path))
+	}))
+	defer server.Close()
+
+	config := EsiParserConfig{
+		DefaultUrl:      server.URL + "/base/",
+		MaxDepth:        1,
+		Timeout:         1 * time.Second,
+		BlockPrivateIPs: false,
 	}
 
-	for _, c := range cases {
-		t.Run(c.url, func(t *testing.T) {
-			parsed, err := url.Parse(c.url)
-			if err != nil {
-				if !c.wantErr {
-					t.Errorf("unexpected parse error for %q: %v", c.url, err)
-				}
-				return
-			}
-
-			isInvalid := parsed.Scheme != "" && parsed.Scheme != "http" && parsed.Scheme != "https"
-			if c.wantErr && !isInvalid {
-				t.Errorf("expected invalid scheme for %q, but it was accepted", c.url)
-			}
-			if !c.wantErr && isInvalid {
-				t.Errorf("expected valid scheme for %q, but was rejected", c.url)
-			}
-		})
+	_, _, err := singleFetchUrl("relative/path", config)
+	if err != nil {
+		t.Errorf("relative URL should resolve to %s/base/relative/path, got error: %v", server.URL, err)
 	}
+}
+
+func TestSingleFetchUrlWithServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ok" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("OK"))
+		} else if r.URL.Path == "/esi" {
+			w.Header().Set("Edge-control", "dca=esi")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("ESI_CONTENT"))
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte("NOT_FOUND"))
+		}
+	}))
+	defer server.Close()
+
+	config := EsiParserConfig{
+		DefaultUrl:      "http://127.0.0.1/",
+		MaxDepth:        5,
+		Timeout:         1 * time.Second,
+		BlockPrivateIPs: false,
+	}
+
+	t.Run("successful fetch", func(t *testing.T) {
+		data, isEsi, err := singleFetchUrl(server.URL+"/ok", config)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if data != "OK" {
+			t.Errorf("expected 'OK', got %q", data)
+		}
+		if isEsi {
+			t.Errorf("expected isEsi=false for non-ESI response")
+		}
+	})
+
+	t.Run("ESI response detection", func(t *testing.T) {
+		data, isEsi, err := singleFetchUrl(server.URL+"/esi", config)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if data != "ESI_CONTENT" {
+			t.Errorf("expected 'ESI_CONTENT', got %q", data)
+		}
+		if !isEsi {
+			t.Errorf("expected isEsi=true for ESI response")
+		}
+	})
+
+	t.Run("404 error", func(t *testing.T) {
+		_, _, err := singleFetchUrl(server.URL+"/notexist", config)
+		if err == nil {
+			t.Errorf("expected error for 404")
+		}
+	})
+}
+
+func TestSingleFetchUrlEdgeCases(t *testing.T) {
+	config := EsiParserConfig{
+		DefaultUrl:      "http://127.0.0.1/",
+		MaxDepth:        1,
+		Timeout:         1 * time.Second,
+		BlockPrivateIPs: false,
+	}
+
+	t.Run("empty URL with no default", func(t *testing.T) {
+		noDefaultConfig := EsiParserConfig{
+			DefaultUrl:      "",
+			MaxDepth:        1,
+			Timeout:         1 * time.Second,
+			BlockPrivateIPs: false,
+		}
+		_, _, err := singleFetchUrl("", noDefaultConfig)
+		if err == nil {
+			t.Errorf("expected error for empty URL")
+		}
+	})
+
+	t.Run("URL with no host", func(t *testing.T) {
+		_, _, err := singleFetchUrl("http://", config)
+		if err == nil {
+			t.Errorf("expected error for URL with no host")
+		}
+	})
+
+	t.Run("backslash in relative URL", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(r.URL.Path))
+		}))
+		defer server.Close()
+
+		testConfig := EsiParserConfig{
+			DefaultUrl:      server.URL + "/",
+			MaxDepth:        1,
+			Timeout:         1 * time.Second,
+			BlockPrivateIPs: false,
+		}
+
+		_, _, err := singleFetchUrl("..\\..\\etc\\passwd", testConfig)
+		if err != nil {
+			t.Errorf("unexpected error for backslash path: %v", err)
+		}
+	})
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
 }

--- a/mesi/fetchUrl_test.go
+++ b/mesi/fetchUrl_test.go
@@ -52,7 +52,7 @@ func TestSingleFetchUrlSchemeValidation(t *testing.T) {
 func TestSingleFetchUrlRelativeUrl(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(r.URL.Path))
+		_, _ = w.Write([]byte(r.URL.Path))
 	}))
 	defer server.Close()
 
@@ -73,14 +73,14 @@ func TestSingleFetchUrlWithServer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/ok" {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("OK"))
+			_, _ = w.Write([]byte("OK"))
 		} else if r.URL.Path == "/esi" {
 			w.Header().Set("Edge-control", "dca=esi")
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("ESI_CONTENT"))
+			_, _ = w.Write([]byte("ESI_CONTENT"))
 		} else {
 			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte("NOT_FOUND"))
+			_, _ = w.Write([]byte("NOT_FOUND"))
 		}
 	}))
 	defer server.Close()
@@ -157,7 +157,7 @@ func TestSingleFetchUrlEdgeCases(t *testing.T) {
 	t.Run("backslash in relative URL", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(r.URL.Path))
+			_, _ = w.Write([]byte(r.URL.Path))
 		}))
 		defer server.Close()
 

--- a/mesi/fetchUrl_test.go
+++ b/mesi/fetchUrl_test.go
@@ -1,0 +1,104 @@
+package mesi
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestUrlSchemeValidation(t *testing.T) {
+	validSchemes := []string{"http", "https"}
+	invalidSchemes := []string{"httpx", "httpfoo", "httpss", "ftp", "file", "javascript", "data", "gopher"}
+
+	baseHost := "://example.com/path"
+
+	for _, scheme := range validSchemes {
+		u := scheme + baseHost
+		parsed, err := url.Parse(u)
+		if err != nil {
+			t.Errorf("valid scheme %q failed to parse: %v", scheme, err)
+			continue
+		}
+		if parsed.Scheme != scheme {
+			t.Errorf("expected scheme %q, got %q", scheme, parsed.Scheme)
+		}
+	}
+
+	for _, scheme := range invalidSchemes {
+		u := scheme + baseHost
+		parsed, err := url.Parse(u)
+		if err != nil {
+			t.Errorf("invalid scheme %q failed to parse: %v", scheme, err)
+			continue
+		}
+		if parsed.Scheme == "http" || parsed.Scheme == "https" {
+			t.Errorf("scheme %q should be rejected but got scheme %q", scheme, parsed.Scheme)
+		}
+	}
+}
+
+func TestRelativeUrlHandling(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		defUrl   string
+		expected string
+	}{
+		{"simple relative", "foo/bar", "http://base.com/", "http://base.com/foo/bar"},
+		{"absolute path", "/foo/bar", "http://base.com/", "http://base.com/foo/bar"},
+		{"no leading slash", "foo/bar", "http://base.com", "http://base.com/foo/bar"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, _ := url.Parse(tt.input)
+			if parsed.Scheme != "" {
+				t.Errorf("relative URL %q should have empty scheme, got %q", tt.input, parsed.Scheme)
+			}
+
+			result := strings.TrimRight(tt.defUrl, "/") + "/" + strings.TrimLeft(tt.input, "/")
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestUrlSchemeCheckLogic(t *testing.T) {
+	cases := []struct {
+		url     string
+		wantErr bool
+		errMsg  string
+	}{
+		{"http://example.com", false, ""},
+		{"https://example.com", false, ""},
+		{"http://example.com/path?query=1", false, ""},
+		{"https://example.com/path#anchor", false, ""},
+		{"httpx://example.com", true, "invalid url scheme"},
+		{"httpfoo://example.com", true, "invalid url scheme"},
+		{"httpss://example.com", true, "invalid url scheme"},
+		{"ftp://example.com", true, "invalid url scheme"},
+		{"file:///etc/passwd", true, "invalid url scheme"},
+		{"javascript:alert(1)", true, "invalid url scheme"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.url, func(t *testing.T) {
+			parsed, err := url.Parse(c.url)
+			if err != nil {
+				if !c.wantErr {
+					t.Errorf("unexpected parse error for %q: %v", c.url, err)
+				}
+				return
+			}
+
+			isInvalid := parsed.Scheme != "" && parsed.Scheme != "http" && parsed.Scheme != "https"
+			if c.wantErr && !isInvalid {
+				t.Errorf("expected invalid scheme for %q, but it was accepted", c.url)
+			}
+			if !c.wantErr && isInvalid {
+				t.Errorf("expected valid scheme for %q, but was rejected", c.url)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Replace `strings.HasPrefix` URL validation with proper `url.Parse()` + scheme check
- Only `http` and `https` schemes are now allowed
- Invalid schemes like `httpx://`, `ftp://`, `javascript:` are now rejected

## Security Impact
Fixes SSRF bypass via non-standard URL schemes (e.g., `httpx://`, `httpfoo://`)

## Testing
- Added unit tests for URL scheme validation (`mesi/fetchUrl_test.go`)

## Fixes
Fixes #22