### PR TITLE
fix: propagate request context to ESI sub-requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ go.work.sum
 
 # Compiled binaries
 cli/cli
+tests/tests
 
 .idea
 /servers/test-server/example-server

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ go.work.sum
 # env file
 .env
 
+# Compiled binaries
+cli/cli
+
 .idea
 /servers/test-server/example-server
 /libgomesi/test-libgomesi

--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -1,6 +1,7 @@
 package mesi
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net"
@@ -79,7 +80,18 @@ func isPrivateOrReservedIP(ip net.IP) bool {
 	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsUnspecified()
 }
 
+// Deprecated: singleFetchUrl does not support context propagation.
+// Use singleFetchUrlWithContext instead for proper cancellation support.
 func singleFetchUrl(requestedURL string, config EsiParserConfig) (data string, esiResponse bool, err error) {
+	return singleFetchUrlWithContext(requestedURL, config, config.Context)
+}
+
+// singleFetchUrlWithContext fetches a URL with context support for proper cancellation.
+func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx context.Context) (data string, esiResponse bool, err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	if config.Timeout <= 0 {
 		return "", false, errors.New("exceeded time budget")
 	}
@@ -111,7 +123,7 @@ func singleFetchUrl(requestedURL string, config EsiParserConfig) (data string, e
 		urlToFetch = requestedURL
 	}
 
-	req, err := http.NewRequest("GET", urlToFetch, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", urlToFetch, nil)
 	if err != nil {
 		return "", false, errors.New("failed to create request: " + err.Error())
 	}

--- a/mesi/fetchUrl_test.go
+++ b/mesi/fetchUrl_test.go
@@ -1,8 +1,10 @@
 package mesi
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -186,4 +188,171 @@ func containsHelper(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func TestSingleFetchUrlWithContextCancellation(t *testing.T) {
+	requestReceived := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestReceived)
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(5 * time.Second):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("SHOULD NOT SEE THIS"))
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	config := EsiParserConfig{
+		Context:         ctx,
+		DefaultUrl:      "http://127.0.0.1/",
+		MaxDepth:        1,
+		Timeout:         10 * time.Second,
+		BlockPrivateIPs: false,
+	}
+
+	go func() {
+		<-requestReceived
+		cancel()
+	}()
+
+	_, _, err := singleFetchUrl(server.URL+"/slow", config)
+
+	if err == nil {
+		t.Error("expected context cancelled error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "context") {
+		t.Errorf("expected error containing 'context', got: %v", err)
+	}
+}
+
+func TestSingleFetchUrlWithContextTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("DONE"))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	config := EsiParserConfig{
+		Context:         ctx,
+		DefaultUrl:      "http://127.0.0.1/",
+		MaxDepth:        1,
+		Timeout:         10 * time.Second,
+		BlockPrivateIPs: false,
+	}
+
+	_, _, err := singleFetchUrl(server.URL+"/slow", config)
+
+	if err == nil {
+		t.Error("expected timeout error, got nil")
+	}
+}
+
+func TestSingleFetchUrlWithNilContext(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer server.Close()
+
+	config := EsiParserConfig{
+		Context:         nil,
+		DefaultUrl:      server.URL,
+		MaxDepth:        1,
+		Timeout:         1 * time.Second,
+		BlockPrivateIPs: false,
+	}
+
+	data, _, err := singleFetchUrl(server.URL+"/ok", config)
+	if err != nil {
+		t.Errorf("unexpected error with nil context: %v", err)
+	}
+	if data != "OK" {
+		t.Errorf("expected 'OK', got %q", data)
+	}
+}
+
+func TestMESIParseContextPropagation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(5 * time.Second):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("SLOW_RESPONSE"))
+		}
+	}))
+	defer server.Close()
+
+	html := `<html><body><esi:include src="` + server.URL + `/slow"/></body></html>`
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	config := EsiParserConfig{
+		Context:         ctx,
+		DefaultUrl:      "http://example.com/",
+		MaxDepth:        5,
+		Timeout:         10 * time.Second,
+		BlockPrivateIPs: false,
+	}
+
+	cancel()
+
+	start := time.Now()
+	result := MESIParse(html, config)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Errorf("MESIParse took too long (%v) - context not propagated properly", elapsed)
+	}
+
+	if result == "" {
+		t.Log("result is empty (expected with cancelled context)")
+	}
+}
+
+func TestMESIParseContextCancellationStopsAllGoroutines(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(5 * time.Second):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("SLOW"))
+		}
+	}))
+	defer server.Close()
+
+	html := `<html><body><esi:include src="` + server.URL + `/slow"/><esi:include src="` + server.URL + `/slow"/></body></html>`
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	config := EsiParserConfig{
+		Context:         ctx,
+		DefaultUrl:      "http://example.com/",
+		MaxDepth:        5,
+		Timeout:         10 * time.Second,
+		BlockPrivateIPs: false,
+	}
+
+	cancel()
+
+	start := time.Now()
+	result := MESIParse(html, config)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Errorf("MESIParse took too long (%v) with cancelled context", elapsed)
+	}
+
+	_ = result
 }

--- a/mesi/include.go
+++ b/mesi/include.go
@@ -98,7 +98,7 @@ func (ratio abRatio) selectUrl(token *esiIncludeToken) string {
 }
 
 func fetchAB(token *esiIncludeToken, config EsiParserConfig) (string, bool, error) {
-	return singleFetchUrl(token.parseAB().selectUrl(token), config)
+	return singleFetchUrlWithContext(token.parseAB().selectUrl(token), config, config.Context)
 }
 
 func fetchConcurrent(token *esiIncludeToken, config EsiParserConfig) (string, bool, error) {
@@ -110,6 +110,9 @@ func fetchConcurrent(token *esiIncludeToken, config EsiParserConfig) (string, bo
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	if config.Context != nil {
+		ctx, cancel = context.WithCancel(config.Context)
+	}
 	defer cancel()
 	resultChan := make(chan esiResponse)
 
@@ -118,7 +121,7 @@ func fetchConcurrent(token *esiIncludeToken, config EsiParserConfig) (string, bo
 		case <-ctx.Done():
 			return
 		default:
-			data, isEsiResponse, err := singleFetchUrl(url, config)
+			data, isEsiResponse, err := singleFetchUrlWithContext(url, config, ctx)
 			select {
 			case resultChan <- esiResponse{Data: data, IsEsiResponse: isEsiResponse, Error: err}:
 			case <-ctx.Done():
@@ -143,9 +146,9 @@ func fetchFallback(token *esiIncludeToken, config EsiParserConfig) (string, bool
 	var err error
 	var isEsiResponse bool
 
-	data, isEsiResponse, err = singleFetchUrl(token.Src, config)
+	data, isEsiResponse, err = singleFetchUrlWithContext(token.Src, config, config.Context)
 	if err != nil && token.Alt != "" {
-		return singleFetchUrl(token.Alt, config.WithElapsedTime(time.Since(start)))
+		return singleFetchUrlWithContext(token.Alt, config.WithElapsedTime(time.Since(start)), config.Context)
 	}
 
 	return data, isEsiResponse, err

--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -1,6 +1,7 @@
 package mesi
 
 import (
+	"context"
 	"sort"
 	"strconv"
 	"strings"
@@ -14,6 +15,7 @@ type Response struct {
 }
 
 type EsiParserConfig struct {
+	Context         context.Context
 	DefaultUrl      string
 	MaxDepth        uint
 	Timeout         time.Duration
@@ -22,8 +24,14 @@ type EsiParserConfig struct {
 	BlockPrivateIPs bool
 }
 
+func (c EsiParserConfig) SetContext(ctx context.Context) EsiParserConfig {
+	c.Context = ctx
+	return c
+}
+
 func CreateDefaultConfig() EsiParserConfig {
 	return EsiParserConfig{
+		Context:         context.Background(),
 		DefaultUrl:      "http://127.0.0.1/",
 		MaxDepth:        5,
 		Timeout:         10 * time.Second,
@@ -84,9 +92,22 @@ func (c EsiParserConfig) OverrideConfig(token esiIncludeToken) EsiParserConfig {
 	return c
 }
 
+func handleContextCancellation(results []Response, result strings.Builder) string {
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].index < results[j].index
+	})
+
+	for _, res := range results {
+		result.WriteString(res.content)
+	}
+
+	return result.String()
+}
+
 // Deprecated: FunctionName is deprecated, please use mEsiParse
 func Parse(input string, maxDepth int, defaultUrl string) string {
 	config := EsiParserConfig{
+		Context:         context.Background(),
 		DefaultUrl:      defaultUrl,
 		MaxDepth:        uint(maxDepth),
 		Timeout:         10 * time.Second,
@@ -97,13 +118,16 @@ func Parse(input string, maxDepth int, defaultUrl string) string {
 }
 
 func MESIParse(input string, config EsiParserConfig) string {
+	if config.Context == nil {
+		config.Context = context.Background()
+	}
 	start := time.Now()
 	var wg sync.WaitGroup
 
 	var result strings.Builder
 	processed := unescape(input)
 	tokens := esiTokenizer(processed)
-	ch := make(chan Response)
+	ch := make(chan Response, len(tokens))
 	wg.Add(len(tokens))
 	go func() {
 		wg.Wait()
@@ -111,7 +135,7 @@ func MESIParse(input string, config EsiParserConfig) string {
 	}()
 
 	for index, token := range tokens {
-		go func(id int, token esiToken, wg *sync.WaitGroup, ch chan<- Response) {
+		go func(id int, token esiToken, wg *sync.WaitGroup, ch chan<- Response, cfg EsiParserConfig) {
 			defer wg.Done()
 			res := Response{"", id}
 			if !token.isEsi() {
@@ -123,10 +147,10 @@ func MESIParse(input string, config EsiParserConfig) string {
 					ch <- res
 					return
 				}
-				newConfig := config.OverrideConfig(include).WithElapsedTime(time.Since(start))
+				newConfig := cfg.OverrideConfig(include).WithElapsedTime(time.Since(start))
 				content, isEsiResponse := include.toString(newConfig)
 
-				if config.CanGoDeeper(time.Since(start)) && (isEsiResponse || !newConfig.ParseOnHeader) {
+				if cfg.CanGoDeeper(time.Since(start)) && (isEsiResponse || !newConfig.ParseOnHeader) {
 					content = MESIParse(content, newConfig.DecreaseMaxDepth().WithElapsedTime(time.Since(start)))
 				}
 
@@ -134,13 +158,22 @@ func MESIParse(input string, config EsiParserConfig) string {
 			}
 
 			ch <- res
-		}(index, token, &wg, ch)
+		}(index, token, &wg, ch, config)
 	}
 
 	var results []Response
-	for res := range ch {
-		results = append(results, res)
+	for {
+		select {
+		case <-config.Context.Done():
+			return handleContextCancellation(results, result)
+		case res, ok := <-ch:
+			if !ok {
+				goto done
+			}
+			results = append(results, res)
+		}
 	}
+done:
 
 	sort.Slice(results, func(i, j int) bool {
 		return results[i].index < results[j].index

--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -92,7 +92,7 @@ func (c EsiParserConfig) OverrideConfig(token esiIncludeToken) EsiParserConfig {
 	return c
 }
 
-func handleContextCancellation(results []Response, result strings.Builder) string {
+func assembleResults(results []Response, result strings.Builder) string {
 	sort.Slice(results, func(i, j int) bool {
 		return results[i].index < results[j].index
 	})
@@ -162,26 +162,18 @@ func MESIParse(input string, config EsiParserConfig) string {
 	}
 
 	var results []Response
+ResultLoop:
 	for {
 		select {
 		case <-config.Context.Done():
-			return handleContextCancellation(results, result)
+			return assembleResults(results, result)
 		case res, ok := <-ch:
 			if !ok {
-				goto done
+				break ResultLoop
 			}
 			results = append(results, res)
 		}
 	}
-done:
 
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].index < results[j].index
-	})
-
-	for _, res := range results {
-		result.WriteString(res.content)
-	}
-
-	return result.String()
+	return assembleResults(results, result)
 }

--- a/middleware/responsewriter.go
+++ b/middleware/responsewriter.go
@@ -34,3 +34,19 @@ func (rw *ResponseWriter) StatusCode() int {
 func (rw *ResponseWriter) Body() *bytes.Buffer {
 	return rw.body
 }
+
+func GetScheme(r *http.Request) string {
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}
+
+func GetDefaultUrl(r *http.Request) string {
+	scheme := GetScheme(r)
+	host := r.Host
+	if host == "" {
+		host = "localhost"
+	}
+	return scheme + "://" + host
+}

--- a/servers/caddy/mesi.go
+++ b/servers/caddy/mesi.go
@@ -1,15 +1,17 @@
 package caddy
 
 import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/crazy-goat/go-mesi/mesi"
 	"github.com/crazy-goat/go-mesi/middleware"
-	"net/http"
-	"strconv"
-	"strings"
 )
 
 func init() {
@@ -18,6 +20,22 @@ func init() {
 }
 
 type MesiMiddleware struct{}
+
+func getScheme(r *http.Request) string {
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}
+
+func getDefaultUrl(r *http.Request) string {
+	scheme := getScheme(r)
+	host := r.Host
+	if host == "" {
+		host = "localhost"
+	}
+	return scheme + "://" + host
+}
 
 func (MesiMiddleware) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
@@ -38,10 +56,16 @@ func (MesiMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 
 	contentType := customWriter.Header().Get("Content-Type")
 	if strings.HasPrefix(contentType, "text/html") {
-		processedResponse := mesi.Parse(
+		config := mesi.EsiParserConfig{
+			Context:         r.Context(),
+			MaxDepth:        5,
+			DefaultUrl:      getDefaultUrl(r),
+			Timeout:         10 * time.Second,
+			BlockPrivateIPs: true,
+		}
+		processedResponse := mesi.MESIParse(
 			customWriter.Body().String(),
-			5,
-			r.URL.Scheme+"://"+r.URL.Host,
+			config,
 		)
 
 		w.Header().Set("Content-Length", strconv.Itoa(len(processedResponse)))

--- a/servers/caddy/mesi.go
+++ b/servers/caddy/mesi.go
@@ -21,22 +21,6 @@ func init() {
 
 type MesiMiddleware struct{}
 
-func getScheme(r *http.Request) string {
-	if r.TLS != nil {
-		return "https"
-	}
-	return "http"
-}
-
-func getDefaultUrl(r *http.Request) string {
-	scheme := getScheme(r)
-	host := r.Host
-	if host == "" {
-		host = "localhost"
-	}
-	return scheme + "://" + host
-}
-
 func (MesiMiddleware) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID:  "http.handlers.mesi",
@@ -59,7 +43,7 @@ func (MesiMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 		config := mesi.EsiParserConfig{
 			Context:         r.Context(),
 			MaxDepth:        5,
-			DefaultUrl:      getDefaultUrl(r),
+			DefaultUrl:      middleware.GetDefaultUrl(r),
 			Timeout:         10 * time.Second,
 			BlockPrivateIPs: true,
 		}

--- a/servers/roadrunner/mesi.go
+++ b/servers/roadrunner/mesi.go
@@ -1,11 +1,13 @@
 package roadrunner
 
 import (
-	"github.com/crazy-goat/go-mesi/mesi"
-	"github.com/crazy-goat/go-mesi/middleware"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
+
+	"github.com/crazy-goat/go-mesi/mesi"
+	"github.com/crazy-goat/go-mesi/middleware"
 )
 
 const PluginName = "mesi"
@@ -15,6 +17,22 @@ type Plugin struct {
 
 func (p *Plugin) Init() error {
 	return nil
+}
+
+func getScheme(r *http.Request) string {
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}
+
+func getDefaultUrl(r *http.Request) string {
+	scheme := getScheme(r)
+	host := r.Host
+	if host == "" {
+		host = "localhost"
+	}
+	return scheme + "://" + host
 }
 
 func (p *Plugin) Middleware(next http.Handler) http.Handler {
@@ -27,10 +45,16 @@ func (p *Plugin) Middleware(next http.Handler) http.Handler {
 
 		contentType := customWriter.Header().Get("Content-Type")
 		if strings.HasPrefix(contentType, "text/html") {
-			processedResponse := mesi.Parse(
+			config := mesi.EsiParserConfig{
+				Context:         r.Context(),
+				MaxDepth:        5,
+				DefaultUrl:      getDefaultUrl(r),
+				Timeout:         10 * time.Second,
+				BlockPrivateIPs: true,
+			}
+			processedResponse := mesi.MESIParse(
 				customWriter.Body().String(),
-				5,
-				r.URL.Scheme+"://"+r.URL.Host,
+				config,
 			)
 
 			w.Header().Set("Content-Length", strconv.Itoa(len(processedResponse)))

--- a/servers/roadrunner/mesi.go
+++ b/servers/roadrunner/mesi.go
@@ -19,22 +19,6 @@ func (p *Plugin) Init() error {
 	return nil
 }
 
-func getScheme(r *http.Request) string {
-	if r.TLS != nil {
-		return "https"
-	}
-	return "http"
-}
-
-func getDefaultUrl(r *http.Request) string {
-	scheme := getScheme(r)
-	host := r.Host
-	if host == "" {
-		host = "localhost"
-	}
-	return scheme + "://" + host
-}
-
 func (p *Plugin) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r.Header.Set("Surrogate-Capability", "ESI/1.0")
@@ -48,7 +32,7 @@ func (p *Plugin) Middleware(next http.Handler) http.Handler {
 			config := mesi.EsiParserConfig{
 				Context:         r.Context(),
 				MaxDepth:        5,
-				DefaultUrl:      getDefaultUrl(r),
+				DefaultUrl:      middleware.GetDefaultUrl(r),
 				Timeout:         10 * time.Second,
 				BlockPrivateIPs: true,
 			}

--- a/servers/traefik/mesi.go
+++ b/servers/traefik/mesi.go
@@ -44,22 +44,6 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 	}, nil
 }
 
-func getScheme(r *http.Request) string {
-	if r.TLS != nil {
-		return "https"
-	}
-	return "http"
-}
-
-func getDefaultUrl(r *http.Request) string {
-	scheme := getScheme(r)
-	host := r.Host
-	if host == "" {
-		host = "localhost"
-	}
-	return scheme + "://" + host
-}
-
 func (p *ResponsePlugin) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	customWriter := middleware.NewResponseWriter(rw)
@@ -77,7 +61,7 @@ func (p *ResponsePlugin) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		config := mesi.EsiParserConfig{
 			Context:         req.Context(),
 			MaxDepth:        uint(p.config.MaxDepth),
-			DefaultUrl:      getDefaultUrl(req),
+			DefaultUrl:      middleware.GetDefaultUrl(req),
 			Timeout:         10 * time.Second,
 			BlockPrivateIPs: true,
 		}

--- a/servers/traefik/mesi.go
+++ b/servers/traefik/mesi.go
@@ -3,11 +3,13 @@ package traefik
 import (
 	"context"
 	"fmt"
-	"github.com/crazy-goat/go-mesi/mesi"
-	"github.com/crazy-goat/go-mesi/middleware"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
+
+	"github.com/crazy-goat/go-mesi/mesi"
+	"github.com/crazy-goat/go-mesi/middleware"
 )
 
 type Config struct {
@@ -42,6 +44,22 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 	}, nil
 }
 
+func getScheme(r *http.Request) string {
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}
+
+func getDefaultUrl(r *http.Request) string {
+	scheme := getScheme(r)
+	host := r.Host
+	if host == "" {
+		host = "localhost"
+	}
+	return scheme + "://" + host
+}
+
 func (p *ResponsePlugin) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	customWriter := middleware.NewResponseWriter(rw)
@@ -51,16 +69,21 @@ func (p *ResponsePlugin) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		req.Header.Set("Surrogate-Capability", "ESI/1.0")
 	}
 
-	// Call the next handler
 	p.next.ServeHTTP(customWriter, req)
 
 	contentType := customWriter.Header().Get("Content-Type")
 
 	if strings.HasPrefix(contentType, "text/html") {
-		processedResponse := mesi.Parse(
+		config := mesi.EsiParserConfig{
+			Context:         req.Context(),
+			MaxDepth:        uint(p.config.MaxDepth),
+			DefaultUrl:      getDefaultUrl(req),
+			Timeout:         10 * time.Second,
+			BlockPrivateIPs: true,
+		}
+		processedResponse := mesi.MESIParse(
 			customWriter.Body().String(),
-			p.config.MaxDepth,
-			req.URL.Scheme+"://"+req.URL.Host,
+			config,
 		)
 		rw.Header().Set("Content-Length", strconv.Itoa(len(processedResponse)))
 		for k, v := range customWriter.Header() {
@@ -68,7 +91,6 @@ func (p *ResponsePlugin) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 		rw.WriteHeader(customWriter.StatusCode())
 
-		// Write the processed response
 		rw.Write([]byte(processedResponse))
 
 		return

--- a/tests/e2e.go
+++ b/tests/e2e.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sort"
@@ -65,6 +66,7 @@ func main() {
 		start := time.Now()
 
 		result := mesi.MESIParse(string(testData), mesi.EsiParserConfig{
+			Context:       context.Background(),
 			DefaultUrl:    "http://127.0.0.1:8080",
 			MaxDepth:      5,
 			ParseOnHeader: true,


### PR DESCRIPTION
## Summary
ESI sub-requests now respect client disconnect via request context propagation.

### Core Changes
- Add `Context` field to `EsiParserConfig` to carry request context through the parsing chain
- Use `http.NewRequestWithContext` instead of `http.NewRequest` in `singleFetchUrl`
- Update `fetchConcurrent` to inherit context from config instead of `context.Background()`
- Middleware (Traefik, Caddy, Roadrunner) now pass `r.Context()` to `MESIParse`
- `MESIParse` returns early when context is cancelled (using buffered channel)

### Additional Improvements (from code review)
- Add `SetContext()` method for cleaner API
- Add `BlockPrivateIPs: true` to all middleware configs (SSRF protection was disabled!)
- Fix `DefaultUrl` scheme/host handling in middleware (use `r.TLS`, fallback to `localhost`)
- Add deprecation comment to `singleFetchUrl` (use `singleFetchUrlWithContext` instead)

### Testing
- 3 new tests for `singleFetchUrl`: cancellation, timeout, nil context
- 2 new integration tests for `MESIParse`: context propagation, multiple goroutines
- All existing tests pass

## Fixes
Fixes #21