### PR TITLE
fix: write non-HTML responses in Caddy and Roadrunner middleware

### DIFF
--- a/servers/caddy/mesi.go
+++ b/servers/caddy/mesi.go
@@ -53,11 +53,12 @@ func (MesiMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 		)
 
 		w.Header().Set("Content-Length", strconv.Itoa(len(processedResponse)))
-		for k, v := range customWriter.Header() {
-			w.Header()[k] = v
-		}
 		w.WriteHeader(customWriter.StatusCode())
 		w.Write([]byte(processedResponse))
+	} else {
+		w.Header().Set("Content-Length", strconv.Itoa(customWriter.Body().Len()))
+		w.WriteHeader(customWriter.StatusCode())
+		w.Write(customWriter.Body().Bytes())
 	}
 
 	return nil

--- a/servers/roadrunner/mesi.go
+++ b/servers/roadrunner/mesi.go
@@ -42,11 +42,12 @@ func (p *Plugin) Middleware(next http.Handler) http.Handler {
 			)
 
 			w.Header().Set("Content-Length", strconv.Itoa(len(processedResponse)))
-			for k, v := range customWriter.Header() {
-				w.Header()[k] = v
-			}
 			w.WriteHeader(customWriter.StatusCode())
 			w.Write([]byte(processedResponse))
+		} else {
+			w.Header().Set("Content-Length", strconv.Itoa(customWriter.Body().Len()))
+			w.WriteHeader(customWriter.StatusCode())
+			w.Write(customWriter.Body().Bytes())
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Fixed bug where non-HTML responses (JSON, CSS, JS, images) were silently dropped in Caddy and Roadrunner middleware.

## Problem

Both middlewares captured responses in a custom `responseWriter`, but only wrote back to client for `text/html` content. Non-HTML responses were returned empty.

## Solution

Added `else` branch matching Traefik pattern - writes captured body for non-HTML content.

## Files changed

- `servers/caddy/mesi.go`
- `servers/roadrunner/mesi.go`

## Issue

Fixes #24