### PR TITLE
feat: implement http.Flusher and http.Hijacker on ResponseWriter

### DIFF
--- a/middleware/responsewriter.go
+++ b/middleware/responsewriter.go
@@ -8,6 +8,11 @@ import (
 )
 
 type ResponseWriter struct {
+	// ResponseWriter wraps an http.ResponseWriter to capture the response body.
+	// Note: Write() buffers data internally, so Flush() only works for HTTP/2
+	// compatibility but not for true streaming (SSE, chunked transfer).
+	// For streaming responses, consider bypassing this wrapper or using a
+	// different architecture that writes directly to the underlying writer.
 	http.ResponseWriter
 	statusCode int
 	body       *bytes.Buffer

--- a/middleware/responsewriter.go
+++ b/middleware/responsewriter.go
@@ -1,7 +1,9 @@
 package middleware
 
 import (
+	"bufio"
 	"bytes"
+	"net"
 	"net/http"
 )
 
@@ -33,6 +35,19 @@ func (rw *ResponseWriter) StatusCode() int {
 
 func (rw *ResponseWriter) Body() *bytes.Buffer {
 	return rw.body
+}
+
+func (rw *ResponseWriter) Flush() {
+	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (rw *ResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := rw.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, http.ErrNotSupported
 }
 
 func GetScheme(r *http.Request) string {

--- a/middleware/responsewriter_test.go
+++ b/middleware/responsewriter_test.go
@@ -76,3 +76,37 @@ func TestResponseWriter_StatusCode_Default(t *testing.T) {
 		t.Errorf("expected default StatusCode %d, got %d", http.StatusOK, rw.StatusCode())
 	}
 }
+
+func TestResponseWriter_Flush(t *testing.T) {
+	w := httptest.NewRecorder()
+	rw := NewResponseWriter(w)
+
+	rw.Write([]byte("test"))
+	rw.Flush()
+
+	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
+		_ = f
+	} else {
+		t.Error("expected ResponseWriter to implement http.Flusher")
+	}
+}
+
+func TestResponseWriter_Hijack(t *testing.T) {
+	w := httptest.NewRecorder()
+	rw := NewResponseWriter(w)
+
+	_, _, err := rw.Hijack()
+	if err != http.ErrNotSupported {
+		t.Errorf("expected http.ErrNotSupported for non-hijacker ResponseWriter, got %v", err)
+	}
+}
+
+func TestResponseWriter_Hijack_ImplementsInterface(t *testing.T) {
+	w := httptest.NewRecorder()
+	rw := NewResponseWriter(w)
+
+	_, ok := interface{}(rw).(http.Hijacker)
+	if !ok {
+		t.Error("ResponseWriter should implement http.Hijacker interface")
+	}
+}

--- a/middleware/responsewriter_test.go
+++ b/middleware/responsewriter_test.go
@@ -1,6 +1,10 @@
 package middleware
 
 import (
+	"bufio"
+	"errors"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -77,36 +81,98 @@ func TestResponseWriter_StatusCode_Default(t *testing.T) {
 	}
 }
 
-func TestResponseWriter_Flush(t *testing.T) {
-	w := httptest.NewRecorder()
-	rw := NewResponseWriter(w)
+func TestResponseWriter_Flush_Delegates(t *testing.T) {
+	var flushed bool
+	mockWriter := &mockFlusher{flushed: &flushed}
+	rw := NewResponseWriter(mockWriter)
 
-	rw.Write([]byte("test"))
 	rw.Flush()
 
-	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
-		_ = f
-	} else {
-		t.Error("expected ResponseWriter to implement http.Flusher")
+	if !flushed {
+		t.Error("expected Flush() to delegate to underlying ResponseWriter")
 	}
 }
 
-func TestResponseWriter_Hijack(t *testing.T) {
+func TestResponseWriter_Flush_NoOp_WhenNotSupported(t *testing.T) {
+	w := httptest.NewRecorder()
+	rw := NewResponseWriter(w)
+
+	rw.Flush()
+}
+
+func TestResponseWriter_Hijack_Success(t *testing.T) {
+	expectedConn := &mockConn{}
+	expectedBuf := &bufio.ReadWriter{}
+	mockWriter := &mockHijacker{conn: expectedConn, buf: expectedBuf}
+	rw := NewResponseWriter(mockWriter)
+
+	conn, buf, err := rw.Hijack()
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if conn != expectedConn {
+		t.Errorf("expected conn %v, got %v", expectedConn, conn)
+	}
+	if buf != expectedBuf {
+		t.Errorf("expected buf %v, got %v", expectedBuf, buf)
+	}
+}
+
+func TestResponseWriter_Hijack_Error(t *testing.T) {
 	w := httptest.NewRecorder()
 	rw := NewResponseWriter(w)
 
 	_, _, err := rw.Hijack()
-	if err != http.ErrNotSupported {
-		t.Errorf("expected http.ErrNotSupported for non-hijacker ResponseWriter, got %v", err)
+	if !errors.Is(err, http.ErrNotSupported) {
+		t.Errorf("expected http.ErrNotSupported, got %v", err)
 	}
 }
 
-func TestResponseWriter_Hijack_ImplementsInterface(t *testing.T) {
+func TestResponseWriter_ImplementsInterfaces(t *testing.T) {
 	w := httptest.NewRecorder()
 	rw := NewResponseWriter(w)
 
-	_, ok := interface{}(rw).(http.Hijacker)
-	if !ok {
-		t.Error("ResponseWriter should implement http.Hijacker interface")
+	if _, ok := interface{}(rw).(http.Flusher); !ok {
+		t.Error("ResponseWriter should implement http.Flusher")
 	}
+
+	if _, ok := interface{}(rw).(http.Hijacker); !ok {
+		t.Error("ResponseWriter should implement http.Hijacker")
+	}
+}
+
+type mockFlusher struct {
+	http.ResponseWriter
+	flushed *bool
+}
+
+func (m *mockFlusher) Flush() {
+	*m.flushed = true
+}
+
+type mockHijacker struct {
+	http.ResponseWriter
+	conn net.Conn
+	buf  *bufio.ReadWriter
+}
+
+func (m *mockHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return m.conn, m.buf, nil
+}
+
+type mockConn struct {
+	net.Conn
+}
+
+func (m *mockConn) Close() error {
+	return nil
+}
+
+func (m *mockConn) Read(b []byte) (n int, err error) {
+	return 0, io.EOF
+}
+
+func (m *mockConn) Write(b []byte) (n int, err error) {
+	return len(b), nil
 }


### PR DESCRIPTION
## Summary
- Add `Flush()` method implementing `http.Flusher` interface
- Add `Hijack()` method implementing `http.Hijacker` interface
- Both delegate to underlying `ResponseWriter` when supported
- Returns `http.ErrNotSupported` for non-hijackable responses

## Fixes
Fixes #28 - breaks HTTP/2, WebSocket, and SSE for proxied responses.

## Testing
- Added unit tests with mocks verifying delegation works
- Added `TestResponseWriter_Hijack_Success` for successful hijack
- All tests pass

## Known Limitations
- `Flush()` provides HTTP/2 compatibility but **won't enable true SSE streaming** 
  because `Write()` buffers data internally. For streaming responses,
  a different architecture would be needed (separate issue).