### PR TITLE
fix: handle error from http.NewRequest in CLI

### DIFF
--- a/cli/mesi-cli.go
+++ b/cli/mesi-cli.go
@@ -51,7 +51,11 @@ func main() {
 		client := http.Client{
 			Timeout: config.Timeout,
 		}
-		req, _ := http.NewRequest("GET", pathOrUrl, nil)
+		req, err := http.NewRequest("GET", pathOrUrl, nil)
+		if err != nil {
+			fmt.Println("Error creating request:", err)
+			os.Exit(1)
+		}
 		req.Header.Set("Surrogate-Capability", "ESI/1.0")
 
 		content, err := client.Do(req)


### PR DESCRIPTION
## Summary

- Handle error from `http.NewRequest()` in CLI tool (`cli/mesi-cli.go:54`)
- Prevents nil pointer panic on malformed URLs

## Changes

- Added error check after `http.NewRequest()` call
- Returns error message and exits gracefully if URL is invalid

Closes #32