### PR TITLE
feat: add MaxConcurrentRequests config option to limit ESI goroutines

### DIFF
--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -15,14 +15,15 @@ type Response struct {
 }
 
 type EsiParserConfig struct {
-	Context         context.Context
-	DefaultUrl      string
-	MaxDepth        uint
-	Timeout         time.Duration
-	ParseOnHeader   bool
-	AllowedHosts    []string
-	BlockPrivateIPs bool
-	MaxResponseSize int64 // 0 = unlimited, default 10MB
+	Context               context.Context
+	DefaultUrl            string
+	MaxDepth              uint
+	Timeout               time.Duration
+	ParseOnHeader         bool
+	AllowedHosts          []string
+	BlockPrivateIPs       bool
+	MaxResponseSize       int64 // 0 = unlimited, default 10MB
+	MaxConcurrentRequests int   // 0 = unlimited (backward compatible)
 }
 
 func (c EsiParserConfig) SetContext(ctx context.Context) EsiParserConfig {
@@ -131,6 +132,14 @@ func MESIParse(input string, config EsiParserConfig) string {
 	tokens := esiTokenizer(processed)
 	ch := make(chan Response, len(tokens))
 	wg.Add(len(tokens))
+
+	var semaphore chan struct{}
+	if config.MaxConcurrentRequests > 0 {
+		semaphore = make(chan struct{}, config.MaxConcurrentRequests)
+	} else if config.MaxConcurrentRequests < 0 {
+		config.MaxConcurrentRequests = 0
+	}
+
 	go func() {
 		wg.Wait()
 		close(ch)
@@ -138,6 +147,10 @@ func MESIParse(input string, config EsiParserConfig) string {
 
 	for index, token := range tokens {
 		go func(id int, token esiToken, wg *sync.WaitGroup, ch chan<- Response, cfg EsiParserConfig) {
+			if semaphore != nil {
+				semaphore <- struct{}{}
+				defer func() { <-semaphore }()
+			}
 			defer wg.Done()
 			res := Response{"", id}
 			if !token.isEsi() {

--- a/mesi/parser_test.go
+++ b/mesi/parser_test.go
@@ -1,6 +1,12 @@
 package mesi
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
 
 func TestParse(t *testing.T) {
 	cases := []struct {
@@ -40,5 +46,73 @@ func TestParse(t *testing.T) {
 				t.Errorf("Parse() = %q, want %q", result, c.expected)
 			}
 		})
+	}
+}
+
+func TestMaxConcurrentRequestsLimitsConcurrency(t *testing.T) {
+	var maxConcurrent int64
+	var current atomic.Int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inc := current.Add(1)
+		old := atomic.LoadInt64(&maxConcurrent)
+		if inc > old {
+			atomic.CompareAndSwapInt64(&maxConcurrent, old, inc)
+		}
+
+		time.Sleep(50 * time.Millisecond)
+
+		current.Add(-1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("content"))
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.MaxConcurrentRequests = 2
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+
+	input := `<!--esi <esi:include src="` + server.URL + `/1"/>--><!--esi <esi:include src="` + server.URL + `/2"/>--><!--esi <esi:include src="` + server.URL + `/3"/>--><!--esi <esi:include src="` + server.URL + `/4"/>--><!--esi <esi:include src="` + server.URL + `/5"/>-->`
+
+	MESIParse(input, config)
+
+	if atomic.LoadInt64(&maxConcurrent) > 2 {
+		t.Errorf("Max concurrent = %d, expected <= 2", atomic.LoadInt64(&maxConcurrent))
+	}
+}
+
+func TestMaxConcurrentRequestsZeroMeansUnlimited(t *testing.T) {
+	var maxConcurrent int64
+	var current atomic.Int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inc := current.Add(1)
+		old := atomic.LoadInt64(&maxConcurrent)
+		if inc > old {
+			atomic.CompareAndSwapInt64(&maxConcurrent, old, inc)
+		}
+
+		time.Sleep(20 * time.Millisecond)
+
+		current.Add(-1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("content"))
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.MaxConcurrentRequests = 0
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+
+	input := `<!--esi <esi:include src="` + server.URL + `/1"/>--><!--esi <esi:include src="` + server.URL + `/2"/>--><!--esi <esi:include src="` + server.URL + `/3"/>-->`
+
+	MESIParse(input, config)
+
+	if atomic.LoadInt64(&maxConcurrent) != 3 {
+		t.Errorf("Max concurrent = %d, expected 3 (unlimited)", atomic.LoadInt64(&maxConcurrent))
 	}
 }


### PR DESCRIPTION
## Summary

Add configurable limit for concurrent ESI sub-request goroutines to prevent DoS when pages contain many `<esi:include>` tags.

## Changes

- Add `MaxConcurrentRequests` field to `EsiParserConfig` (default 0 = unlimited, backward compatible)
- Implement semaphore pattern in `MESIParse` to limit concurrent goroutines
- When set > 0, limits simultaneous HTTP requests during ESI processing

## Usage

```go
config := mesi.CreateDefaultConfig()
config.MaxConcurrentRequests = 10 // max 10 parallel requests
result := mesi.MESIParse(input, config)
```

## Fixes

Fixes #35