### PR TITLE
feat: add shared HTTP client for connection pooling

### DIFF
--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -120,6 +120,9 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 	} else {
 		client = &http.Client{Timeout: config.Timeout}
 	}
+	// Note: When HTTPClient is provided, callers are responsible for setting
+	// appropriate timeouts on the client. The config.Timeout field is only
+	// applied when using the default per-request client.
 
 	var urlToFetch string
 	if parsed.Scheme == "" {

--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -18,6 +18,10 @@ func IsEsiResponse(response *http.Response) bool {
 	return strings.Contains(header, "dca=esi")
 }
 
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 func isURLSafe(requestedURL string, config EsiParserConfig) error {
 	if config.BlockPrivateIPs {
 		parsedURL, err := url.Parse(requestedURL)
@@ -110,8 +114,11 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 		return "", false, errors.New("ssrf validation failed: " + err.Error())
 	}
 
-	client := http.Client{
-		Timeout: config.Timeout,
+	var client httpDoer
+	if config.HTTPClient != nil {
+		client = config.HTTPClient
+	} else {
+		client = &http.Client{Timeout: config.Timeout}
 	}
 
 	var urlToFetch string

--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -2,6 +2,7 @@ package mesi
 
 import (
 	"context"
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -22,8 +23,9 @@ type EsiParserConfig struct {
 	ParseOnHeader         bool
 	AllowedHosts          []string
 	BlockPrivateIPs       bool
-	MaxResponseSize       int64 // 0 = unlimited, default 10MB
-	MaxConcurrentRequests int   // 0 = unlimited (backward compatible)
+	MaxResponseSize       int64        // 0 = unlimited, default 10MB
+	MaxConcurrentRequests int          // 0 = unlimited (backward compatible)
+	HTTPClient            *http.Client // shared client for connection pooling, nil = create per request
 }
 
 func (c EsiParserConfig) SetContext(ctx context.Context) EsiParserConfig {

--- a/mesi/parser_test.go
+++ b/mesi/parser_test.go
@@ -119,6 +119,7 @@ func TestMaxConcurrentRequestsZeroMeansUnlimited(t *testing.T) {
 
 func TestSharedHTTPClientIsUsed(t *testing.T) {
 	var clientCount int64
+	var transportCalls int64
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt64(&clientCount, 1)
@@ -127,8 +128,9 @@ func TestSharedHTTPClientIsUsed(t *testing.T) {
 	}))
 	defer server.Close()
 
+	customTransport := &customTransport{rt: http.DefaultTransport, calls: &transportCalls}
 	config := CreateDefaultConfig()
-	config.HTTPClient = &http.Client{}
+	config.HTTPClient = &http.Client{Transport: customTransport}
 	config.DefaultUrl = server.URL + "/"
 	config.MaxDepth = 1
 	config.BlockPrivateIPs = false
@@ -139,5 +141,43 @@ func TestSharedHTTPClientIsUsed(t *testing.T) {
 
 	if atomic.LoadInt64(&clientCount) != 3 {
 		t.Errorf("HTTP client used %d times, expected 3 (shared client)", atomic.LoadInt64(&clientCount))
+	}
+	if atomic.LoadInt64(&transportCalls) != 3 {
+		t.Errorf("Transport used %d times, expected 3 (same client instance)", atomic.LoadInt64(&transportCalls))
+	}
+}
+
+type customTransport struct {
+	rt    http.RoundTripper
+	calls *int64
+}
+
+func (ct *customTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	atomic.AddInt64(ct.calls, 1)
+	return ct.rt.RoundTrip(r)
+}
+
+func TestNilHTTPClientFallsBackToDefault(t *testing.T) {
+	var requestCount int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&requestCount, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("content"))
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.HTTPClient = nil
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+
+	input := `<!--esi <esi:include src="` + server.URL + `/1"/>-->`
+
+	MESIParse(input, config)
+
+	if atomic.LoadInt64(&requestCount) != 1 {
+		t.Errorf("Request count = %d, expected 1", atomic.LoadInt64(&requestCount))
 	}
 }

--- a/mesi/parser_test.go
+++ b/mesi/parser_test.go
@@ -116,3 +116,28 @@ func TestMaxConcurrentRequestsZeroMeansUnlimited(t *testing.T) {
 		t.Errorf("Max concurrent = %d, expected 3 (unlimited)", atomic.LoadInt64(&maxConcurrent))
 	}
 }
+
+func TestSharedHTTPClientIsUsed(t *testing.T) {
+	var clientCount int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&clientCount, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("content"))
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.HTTPClient = &http.Client{}
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+
+	input := `<!--esi <esi:include src="` + server.URL + `/1"/>--><!--esi <esi:include src="` + server.URL + `/2"/>--><!--esi <esi:include src="` + server.URL + `/3"/>-->`
+
+	MESIParse(input, config)
+
+	if atomic.LoadInt64(&clientCount) != 3 {
+		t.Errorf("HTTP client used %d times, expected 3 (shared client)", atomic.LoadInt64(&clientCount))
+	}
+}


### PR DESCRIPTION
## Summary
Complete the implementation of issue #14 by adding shared HTTP client support.

- Add `HTTPClient` field to `EsiParserConfig` for connection pooling
- Use shared client when provided, fallback to per-request client (backward compatible)

This complements the existing `MaxConcurrentRequests` semaphore implementation from #62.

## Changes
- `mesi/parser.go`: Add `HTTPClient *http.Client` field
- `mesi/fetchUrl.go`: Use shared client via `httpDoer` interface, add timeout docs
- `mesi/parser_test.go`: Add `TestSharedHTTPClientIsUsed` (verifies same transport), `TestNilHTTPClientFallsBackToDefault`

## Notes
- When using custom HTTPClient, caller is responsible for timeout configuration