### PR TITLE
fix: apply MaxConcurrentRequests limit to all HTTP requests

### DIFF
--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -97,6 +97,11 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 		ctx = context.Background()
 	}
 
+	if semaphore := config.getSemaphore(); semaphore != nil {
+		semaphore <- struct{}{}
+		defer func() { <-semaphore }()
+	}
+
 	if config.Timeout <= 0 {
 		return "", false, errors.New("exceeded time budget")
 	}

--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -23,9 +23,19 @@ type EsiParserConfig struct {
 	ParseOnHeader         bool
 	AllowedHosts          []string
 	BlockPrivateIPs       bool
-	MaxResponseSize       int64        // 0 = unlimited, default 10MB
-	MaxConcurrentRequests int          // 0 = unlimited (backward compatible)
-	HTTPClient            *http.Client // shared client for connection pooling, nil = create per request
+	MaxResponseSize       int64         // 0 = unlimited, default 10MB
+	MaxConcurrentRequests int           // 0 = unlimited (backward compatible)
+	HTTPClient            *http.Client  // shared client for connection pooling, nil = create per request
+	requestSemaphore      chan struct{} // semaphore for limiting HTTP requests
+}
+
+func (c EsiParserConfig) getSemaphore() chan struct{} {
+	return c.requestSemaphore
+}
+
+func (c EsiParserConfig) setSemaphore(s chan struct{}) EsiParserConfig {
+	c.requestSemaphore = s
+	return c
 }
 
 func (c EsiParserConfig) SetContext(ctx context.Context) EsiParserConfig {
@@ -136,10 +146,12 @@ func MESIParse(input string, config EsiParserConfig) string {
 	wg.Add(len(tokens))
 
 	var semaphore chan struct{}
+	if config.MaxConcurrentRequests < 0 {
+		config.MaxConcurrentRequests = 0
+	}
 	if config.MaxConcurrentRequests > 0 {
 		semaphore = make(chan struct{}, config.MaxConcurrentRequests)
-	} else if config.MaxConcurrentRequests < 0 {
-		config.MaxConcurrentRequests = 0
+		config = config.setSemaphore(semaphore)
 	}
 
 	go func() {
@@ -149,10 +161,6 @@ func MESIParse(input string, config EsiParserConfig) string {
 
 	for index, token := range tokens {
 		go func(id int, token esiToken, wg *sync.WaitGroup, ch chan<- Response, cfg EsiParserConfig) {
-			if semaphore != nil {
-				semaphore <- struct{}{}
-				defer func() { <-semaphore }()
-			}
 			defer wg.Done()
 			res := Response{"", id}
 			if !token.isEsi() {

--- a/mesi/parser_test.go
+++ b/mesi/parser_test.go
@@ -3,6 +3,7 @@ package mesi
 import (
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -49,38 +50,65 @@ func TestParse(t *testing.T) {
 	}
 }
 
-func TestMaxConcurrentRequestsLimitsConcurrency(t *testing.T) {
-	var maxConcurrent int64
-	var current atomic.Int64
+type concurrentTest struct {
+	name               string
+	maxConcurrent      int
+	tokenCount         int
+	useFetchConcurrent bool
+	expectedMax        int64
+}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		inc := current.Add(1)
-		old := atomic.LoadInt64(&maxConcurrent)
-		if inc > old {
-			atomic.CompareAndSwapInt64(&maxConcurrent, old, inc)
+func runConcurrentTest(t *testing.T, tc concurrentTest) {
+	t.Run(tc.name, func(t *testing.T) {
+		var maxConcurrent int64
+		var current atomic.Int64
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			inc := current.Add(1)
+			old := atomic.LoadInt64(&maxConcurrent)
+			if inc > old {
+				atomic.CompareAndSwapInt64(&maxConcurrent, old, inc)
+			}
+
+			time.Sleep(100 * time.Millisecond)
+
+			current.Add(-1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("content"))
+		}))
+		defer server.Close()
+
+		config := CreateDefaultConfig()
+		config.MaxConcurrentRequests = tc.maxConcurrent
+		config.DefaultUrl = server.URL + "/"
+		config.MaxDepth = 1
+		config.BlockPrivateIPs = false
+
+		var input string
+		for i := 0; i < tc.tokenCount; i++ {
+			if tc.useFetchConcurrent {
+				input += `<!--esi <esi:include src="` + server.URL + `/` + strconv.Itoa(i) + `" alt="` + server.URL + `/` + strconv.Itoa(i) + `alt" fetch-mode="concurrent"/>-->`
+			} else {
+				input += `<!--esi <esi:include src="` + server.URL + `/` + strconv.Itoa(i) + `"/>-->`
+			}
 		}
 
-		time.Sleep(50 * time.Millisecond)
+		MESIParse(input, config)
 
-		current.Add(-1)
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("content"))
-	}))
-	defer server.Close()
+		if atomic.LoadInt64(&maxConcurrent) > tc.expectedMax {
+			t.Errorf("Max concurrent = %d, expected <= %d", atomic.LoadInt64(&maxConcurrent), tc.expectedMax)
+		}
+	})
+}
 
-	config := CreateDefaultConfig()
-	config.MaxConcurrentRequests = 2
-	config.DefaultUrl = server.URL + "/"
-	config.MaxDepth = 1
-	config.BlockPrivateIPs = false
-
-	input := `<!--esi <esi:include src="` + server.URL + `/1"/>--><!--esi <esi:include src="` + server.URL + `/2"/>--><!--esi <esi:include src="` + server.URL + `/3"/>--><!--esi <esi:include src="` + server.URL + `/4"/>--><!--esi <esi:include src="` + server.URL + `/5"/>-->`
-
-	MESIParse(input, config)
-
-	if atomic.LoadInt64(&maxConcurrent) > 2 {
-		t.Errorf("Max concurrent = %d, expected <= 2", atomic.LoadInt64(&maxConcurrent))
-	}
+func TestMaxConcurrentRequestsLimitsConcurrency(t *testing.T) {
+	runConcurrentTest(t, concurrentTest{
+		name:               "basic_limit",
+		maxConcurrent:      2,
+		tokenCount:         5,
+		useFetchConcurrent: false,
+		expectedMax:        2,
+	})
 }
 
 func TestMaxConcurrentRequestsZeroMeansUnlimited(t *testing.T) {
@@ -155,6 +183,16 @@ type customTransport struct {
 func (ct *customTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	atomic.AddInt64(ct.calls, 1)
 	return ct.rt.RoundTrip(r)
+}
+
+func TestFetchConcurrentRespectsMaxConcurrentRequests(t *testing.T) {
+	runConcurrentTest(t, concurrentTest{
+		name:               "fetch_concurrent_with_alt",
+		maxConcurrent:      2,
+		tokenCount:         3,
+		useFetchConcurrent: true,
+		expectedMax:        2,
+	})
 }
 
 func TestNilHTTPClientFallsBackToDefault(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes issue #14 edge case where `fetchConcurrent` with `alt` attribute bypassed `MaxConcurrentRequests` limit
- Moves semaphore control from token level to HTTP request level (`singleFetchUrlWithContext`)
- Adds test `TestFetchConcurrentRespectsMaxConcurrentRequests` to verify the fix

## Changes

- `fetchUrl.go`: Added semaphore acquire/release in `singleFetchUrlWithContext`
- `parser.go`: Added `RequestSemaphore` field, `GetSemaphore()`, `SetSemaphore()` methods; removed token-level limiting
- `parser_test.go`: New test for `fetchConcurrent` with `alt` respecting the limit

## Behavior

`MaxConcurrentRequests=2` now means exactly 2 concurrent HTTP requests, regardless of:
- Number of ESI tokens
- `fetch-mode="concurrent"` with `alt` attribute
- Any other token attributes

Closes #14