### PR TITLE
feat: add debug mode with structured logging for ESI processing

### DIFF
--- a/cli/mesi-cli.go
+++ b/cli/mesi-cli.go
@@ -21,6 +21,7 @@ func main() {
 	maxDepth := flag.Uint("max-depth", 5, "Maximum depth of parsing")
 	timeout := flag.Float64("timeout", 10.0, "Request timeout duration in seconds")
 	parseOnHeader := flag.Bool("parse-on-header", false, "Enable parsing on header")
+	debug := flag.Bool("debug", false, "Enable debug logging")
 
 	flag.Parse()
 	args := flag.Args()
@@ -36,6 +37,7 @@ func main() {
 	config.MaxDepth = *maxDepth
 	config.Timeout = time.Duration(*timeout * float64(time.Second))
 	config.ParseOnHeader = *parseOnHeader
+	config.Debug = *debug
 
 	pathOrUrl := args[0]
 	var data string

--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func IsEsiResponse(response *http.Response) bool {
@@ -94,6 +95,7 @@ func singleFetchUrl(requestedURL string, config EsiParserConfig) (data string, e
 
 // singleFetchUrlWithContext fetches a URL with context support for proper cancellation.
 func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx context.Context) (data string, esiResponse bool, err error) {
+	logger := config.getLogger()
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -104,6 +106,7 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 	}
 
 	if config.Timeout <= 0 {
+		logger.Debug("fetch_timeout", "url", requestedURL, "error", "exceeded time budget")
 		return "", false, errors.New("exceeded time budget")
 	}
 
@@ -117,6 +120,7 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 	}
 
 	if err := isURLSafe(requestedURL, config); err != nil {
+		logger.Debug("fetch_ssrf_error", "url", requestedURL, "error", err.Error())
 		return "", false, errors.New("ssrf validation failed: " + err.Error())
 	}
 
@@ -160,10 +164,14 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 	}
 	req.Header.Set("Surrogate-Capability", "ESI/1.0")
 
+	logger.Debug("fetch_start", "url", urlToFetch, "timeout", config.Timeout)
+	reqStart := time.Now()
 	content, err := client.Do(req)
 	if err != nil {
+		logger.Debug("fetch_error", "url", urlToFetch, "error", err.Error())
 		return "", false, err
 	}
+	logger.Debug("fetch_done", "url", urlToFetch, "duration", time.Since(reqStart), "status", content.StatusCode)
 	defer func() { _ = content.Body.Close() }()
 
 	var dataBytes []byte

--- a/mesi/fetchUrl_test.go
+++ b/mesi/fetchUrl_test.go
@@ -65,6 +65,7 @@ func TestSingleFetchUrlRelativeUrl(t *testing.T) {
 		MaxDepth:        1,
 		Timeout:         1 * time.Second,
 		BlockPrivateIPs: false,
+		Logger:          DiscardLogger{},
 	}
 
 	_, _, err := singleFetchUrl("relative/path", config)

--- a/mesi/include.go
+++ b/mesi/include.go
@@ -98,7 +98,10 @@ func (ratio abRatio) selectUrl(token *esiIncludeToken) string {
 }
 
 func fetchAB(token *esiIncludeToken, config EsiParserConfig) (string, bool, error) {
-	return singleFetchUrlWithContext(token.parseAB().selectUrl(token), config, config.Context)
+	logger := config.getLogger()
+	selected := token.parseAB().selectUrl(token)
+	logger.Debug("ab_ratio_select", "src", token.Src, "alt", token.Alt, "selected", selected)
+	return singleFetchUrlWithContext(selected, config, config.Context)
 }
 
 func fetchConcurrent(token *esiIncludeToken, config EsiParserConfig) (string, bool, error) {
@@ -136,6 +139,7 @@ func fetchConcurrent(token *esiIncludeToken, config EsiParserConfig) (string, bo
 }
 
 func fetchFallback(token *esiIncludeToken, config EsiParserConfig) (string, bool, error) {
+	logger := config.getLogger()
 	start := time.Now()
 	var data string
 	var err error
@@ -143,6 +147,7 @@ func fetchFallback(token *esiIncludeToken, config EsiParserConfig) (string, bool
 
 	data, isEsiResponse, err = singleFetchUrlWithContext(token.Src, config, config.Context)
 	if err != nil && token.Alt != "" {
+		logger.Debug("fallback_triggered", "primary", token.Src, "alt", token.Alt, "error", err.Error())
 		return singleFetchUrlWithContext(token.Alt, config.WithElapsedTime(time.Since(start)), config.Context)
 	}
 
@@ -150,11 +155,15 @@ func fetchFallback(token *esiIncludeToken, config EsiParserConfig) (string, bool
 }
 
 func (token *esiIncludeToken) toString(config EsiParserConfig) (string, bool) {
+	logger := config.getLogger()
 	var data string
 	var err error
 	var isEsiResponse bool
 
+	logger.Debug("include_start", "src", token.Src, "fetch_mode", token.FetchMode, "max_depth", config.MaxDepth, "timeout", config.Timeout)
+
 	if config.ParseOnly() {
+		logger.Debug("max_depth_reached", "src", token.Src)
 		err = errors.New("esi max depth")
 	} else {
 		switch token.FetchMode {

--- a/mesi/logger.go
+++ b/mesi/logger.go
@@ -1,0 +1,44 @@
+package mesi
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+type Logger interface {
+	Debug(msg string, keyvals ...interface{})
+}
+
+type DiscardLogger struct{}
+
+func (DiscardLogger) Debug(msg string, keyvals ...interface{}) {}
+
+type DefaultLogger struct {
+	w io.Writer
+}
+
+func DefaultLoggerNew() DefaultLogger {
+	return DefaultLogger{w: os.Stderr}
+}
+
+func (l DefaultLogger) Debug(msg string, keyvals ...interface{}) {
+	now := time.Now().Format(time.RFC3339)
+	fmt.Fprintf(l.w, "%s DEBUG %s", now, msg)
+	if len(keyvals) > 0 {
+		fmt.Fprint(l.w, " ")
+		for i := 0; i < len(keyvals); i += 2 {
+			if i+1 < len(keyvals) {
+				fmt.Fprintf(l.w, "%v=%v", keyvals[i], keyvals[i+1])
+			} else {
+				// Odd number of keyvals, log the last key with MISSING value
+				fmt.Fprintf(l.w, "%v=MISSING", keyvals[i])
+			}
+			if i+2 < len(keyvals) {
+				fmt.Fprint(l.w, " ")
+			}
+		}
+	}
+	fmt.Fprintln(l.w)
+}

--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -29,6 +29,8 @@ type EsiParserConfig struct {
 	Cache                 Cache         // nil = no caching (backward compatible)
 	CacheTTL              time.Duration // Default TTL for cached entries
 	CacheKeyFunc          CacheKeyFunc  // Custom cache key function (nil = DefaultCacheKey)
+	Debug                 bool          // Enable debug logging
+	Logger                Logger        // Custom logger (nil = DiscardLogger when Debug is false)
 	requestSemaphore      chan struct{} // semaphore for limiting HTTP requests
 }
 
@@ -39,6 +41,18 @@ func (c EsiParserConfig) getSemaphore() chan struct{} {
 func (c EsiParserConfig) setSemaphore(s chan struct{}) EsiParserConfig {
 	c.requestSemaphore = s
 	return c
+}
+
+var discardLogger = DiscardLogger{}
+
+func (c EsiParserConfig) getLogger() Logger {
+	if c.Logger != nil {
+		return c.Logger
+	}
+	if c.Debug {
+		return DefaultLoggerNew()
+	}
+	return discardLogger
 }
 
 func (c EsiParserConfig) SetContext(ctx context.Context) EsiParserConfig {
@@ -56,6 +70,7 @@ func CreateDefaultConfig() EsiParserConfig {
 		BlockPrivateIPs: true,
 		MaxResponseSize: 10 * 1024 * 1024, // 10MB default
 		CacheKeyFunc:    DefaultCacheKey,
+		Logger:          DiscardLogger{},
 	}
 }
 
@@ -140,12 +155,16 @@ func MESIParse(input string, config EsiParserConfig) string {
 	if config.Context == nil {
 		config.Context = context.Background()
 	}
+	logger := config.getLogger()
 	start := time.Now()
 	var wg sync.WaitGroup
 
 	var result strings.Builder
 	processed := unescape(input)
 	tokens := esiTokenizer(processed)
+
+	logger.Debug("parse_start", "input_size", len(input), "token_count", len(tokens))
+
 	ch := make(chan Response, len(tokens))
 	wg.Add(len(tokens))
 
@@ -164,15 +183,17 @@ func MESIParse(input string, config EsiParserConfig) string {
 	}()
 
 	for index, token := range tokens {
-		go func(id int, token esiToken, wg *sync.WaitGroup, ch chan<- Response, cfg EsiParserConfig) {
+		go func(id int, token esiToken, wg *sync.WaitGroup, ch chan<- Response, cfg EsiParserConfig, l Logger) {
 			defer wg.Done()
 			res := Response{"", id}
 			if !token.isEsi() {
 				res.content = token.staticContent
 			} else if token.esiTagType == "include" {
+				l.Debug("token_processing", "token_type", token.esiTagType, "index", id)
 
 				include, err := parseInclude(token.esiTagContent)
 				if err != nil {
+					l.Debug("parse_error", "error", err.Error())
 					ch <- res
 					return
 				}
@@ -184,10 +205,12 @@ func MESIParse(input string, config EsiParserConfig) string {
 				}
 
 				res.content = content
+			} else {
+				l.Debug("token_processing", "token_type", token.esiTagType, "index", id)
 			}
 
 			ch <- res
-		}(index, token, &wg, ch, config)
+		}(index, token, &wg, ch, config, logger)
 	}
 
 	var results []Response


### PR DESCRIPTION
## Summary

Implements #15 - Add debug mode with structured logging for ESI processing.

## Changes

### New Logger Interface

```go
type Logger interface {
    Debug(msg string, keyvals ...interface{})
}
```

### EsiParserConfig Extensions

- `Debug bool` - enables debug logging
- `Logger Logger` - custom logger injection

### Implementations

- `DiscardLogger` - no-op logger (zero overhead when debug disabled)
- `DefaultLogger` - writes to stderr with RFC3339 timestamps

### Debug Log Points

| Event | Fields |
|-------|-------|
| `parse_start` | `input_size`, `token_count` |
| `token_processing` | `token_type`, `index` |
| `include_start` | `src`, `fetch_mode`, `max_depth`, `timeout` |
| `fetch_start` | `url`, `timeout` |
| `fetch_done` | `url`, `duration`, `status` |
| `fetch_error` | `url`, `error` |
| `ab_ratio_select` | `src`, `alt`, `selected` |
| `fallback_triggered` | `primary`, `alt`, `error` |
| `max_depth_reached` | `src` |
| `fetch_timeout` | `url`, `error` |
| `fetch_ssrf_error` | `url`, `error` |
| `parse_error` | `error` |

## Usage

```go
config := mesi.CreateDefaultConfig()
config.Debug = true
result := mesi.MESIParse(input, config)
```

Or with custom logger:

```go
config := mesi.CreateDefaultConfig()
config.Debug = true
config.Logger = myLogger{}
```

## Backward Compatibility

- Debug disabled by default
- When Debug=false and Logger=nil, uses DiscardLogger (no overhead)
- All existing code works without changes