### PR TITLE
fix: normalize go version to major.minor in all go.mod files

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/crazy-goat/go-mesi/cli
 
-go 1.23.5
+go 1.23
 
 replace github.com/crazy-goat/go-mesi => ..
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crazy-goat/go-mesi
 
-go 1.23.5
+go 1.23
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf

--- a/servers/proxy/go.mod
+++ b/servers/proxy/go.mod
@@ -1,6 +1,6 @@
 module github.com/crazy-goat/go-mesi/servers/proxy
 
-go 1.23.5
+go 1.23
 
 require github.com/crazy-goat/go-mesi v0.0.0
 

--- a/servers/roadrunner/go.mod
+++ b/servers/roadrunner/go.mod
@@ -1,6 +1,6 @@
 module github.com/crazy-goat/go-mesi/servers/roadrunner
 
-go 1.23.5
+go 1.23
 
 require github.com/crazy-goat/go-mesi v0.4.1
 

--- a/servers/test-server/go.mod
+++ b/servers/test-server/go.mod
@@ -1,3 +1,3 @@
 module github.com/crazy-goat/go-mesi/servers/test-server
 
-go 1.23.5
+go 1.23

--- a/servers/traefik/go.mod
+++ b/servers/traefik/go.mod
@@ -1,6 +1,6 @@
 module github.com/crazy-goat/go-mesi/servers/traefik
 
-go 1.23.5
+go 1.23
 
 require github.com/crazy-goat/go-mesi v0.0.0-20250204204515-1f5435b2af61
 


### PR DESCRIPTION
Normalizes Go version from 1.23.5 to 1.23 in 6 go.mod files per Go module conventions.