### PR TITLE
fix(tokenizer): return correct staticContent for unclosed tags

### DIFF
--- a/mesi/tokenizer.go
+++ b/mesi/tokenizer.go
@@ -70,7 +70,7 @@ func esiTokenizer(input string) []esiToken {
 		}
 
 		if end == -1 {
-			return append(esiTokens, esiToken{staticContent: input[pos:]})
+			return append(esiTokens, esiToken{staticContent: input[start:]})
 		}
 		end += start + len(endTag)
 

--- a/mesi/tokenizer_test.go
+++ b/mesi/tokenizer_test.go
@@ -63,7 +63,7 @@ func TestEsiTokenizer(t *testing.T) {
 			"Start <esi:include src=\"/a\"",
 			[]esiToken{
 				{staticContent: "Start "},
-				{staticContent: "Start <esi:include src=\"/a\""},
+				{staticContent: "<esi:include src=\"/a\""},
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- Fix tokenizer returning incorrect `staticContent` for unclosed ESI tags
- Changed `input[pos:]` to `input[start:]` at tokenizer.go:73

## Problem
When an ESI tag was not properly closed, the tokenizer returned the entire remaining input from the wrong position, duplicating content that was already in a previous token.

**Input:** `"Start <esi:include src=\"/a\""`
**Before:** Token 2 had `"Start <esi:include src=\"/a\""` (duplicated "Start ")
**After:** Token 2 has `"<esi:include src=\"/a\""` (correct)

Closes #73