### PR TITLE
fix(mesi): prevent SSRF via DNS rebinding (issue #104)

### DIFF
--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -30,40 +31,33 @@ type httpDoer interface {
 }
 
 func isURLSafe(requestedURL string, config EsiParserConfig) error {
-	if config.BlockPrivateIPs {
-		parsedURL, err := url.Parse(requestedURL)
-		if err != nil {
-			return errors.New("invalid url: " + err.Error())
-		}
+	parsedURL, err := url.Parse(requestedURL)
+	if err != nil {
+		return errors.New("invalid url: " + err.Error())
+	}
 
-		host := parsedURL.Host
-		if host == "" {
-			return errors.New("url has no host")
-		}
+	host := parsedURL.Host
 
-		if len(config.AllowedHosts) > 0 {
-			allowed := false
-			for _, allowedHost := range config.AllowedHosts {
-				if host == allowedHost || strings.HasSuffix(host, "."+allowedHost) {
-					allowed = true
-					break
-				}
+	// Relative URLs have no host and no scheme - they will be resolved against DefaultUrl
+	if parsedURL.Scheme == "" && host == "" {
+		return nil
+	}
+
+	// Absolute URLs must have a host
+	if host == "" {
+		return errors.New("url has no host")
+	}
+
+	if len(config.AllowedHosts) > 0 {
+		allowed := false
+		for _, allowedHost := range config.AllowedHosts {
+			if host == allowedHost || strings.HasSuffix(host, "."+allowedHost) {
+				allowed = true
+				break
 			}
-			if !allowed {
-				return errors.New("host not in allowed list: " + host)
-			}
-			return nil
 		}
-
-		ips, err := net.LookupIP(host)
-		if err != nil {
-			return errors.New("cannot resolve host: " + err.Error())
-		}
-
-		for _, ip := range ips {
-			if isPrivateOrReservedIP(ip) {
-				return errors.New("url resolves to private/reserved ip: " + ip.String())
-			}
+		if !allowed {
+			return errors.New("host not in allowed list: " + host)
 		}
 	}
 
@@ -90,6 +84,46 @@ func isPrivateOrReservedIP(ip net.IP) bool {
 	}
 
 	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsUnspecified()
+}
+
+// safeDialer returns a net.Dialer with a Control callback that blocks
+// connections to private/reserved IP addresses at dial time.
+// This prevents SSRF via DNS rebinding attacks (TOCTOU between validation and dial).
+func safeDialer(config EsiParserConfig) *net.Dialer {
+	return &net.Dialer{
+		Control: func(network, address string, c syscall.RawConn) error {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return err
+			}
+			ip := net.ParseIP(host)
+			if ip == nil {
+				return fmt.Errorf("dial address is not an IP: %s", host)
+			}
+			if config.BlockPrivateIPs && isPrivateOrReservedIP(ip) {
+				return fmt.Errorf("blocked dial to private/reserved ip: %s", ip)
+			}
+			return nil
+		},
+	}
+}
+
+// NewSSRFSafeTransport creates an http.Transport that blocks connections to
+// private/reserved IP addresses at dial time, preventing SSRF via DNS rebinding.
+// When config.BlockPrivateIPs is false, it returns a standard transport.
+//
+// Users supplying a custom HTTPClient should use this transport to ensure
+// SSRF protection works correctly:
+//
+//	client := &http.Client{
+//		Transport: mesi.NewSSRFSafeTransport(config),
+//		Timeout:   config.Timeout,
+//	}
+func NewSSRFSafeTransport(config EsiParserConfig) *http.Transport {
+	dialer := safeDialer(config)
+	return &http.Transport{
+		DialContext: dialer.DialContext,
+	}
 }
 
 // Deprecated: singleFetchUrl does not support context propagation.
@@ -133,11 +167,16 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 	if config.HTTPClient != nil {
 		client = config.HTTPClient
 	} else {
-		client = &http.Client{Timeout: config.Timeout}
+		transport := NewSSRFSafeTransport(config)
+		client = &http.Client{
+			Timeout:   config.Timeout,
+			Transport: transport,
+		}
 	}
 	// Note: When HTTPClient is provided, callers are responsible for setting
-	// appropriate timeouts on the client. The config.Timeout field is only
-	// applied when using the default per-request client.
+	// appropriate timeouts and SSRF protection on the client.
+	// Use NewSSRFSafeTransport(config) to create a transport with dial-time
+	// private IP blocking.
 
 	var urlToFetch string
 	if parsed.Scheme == "" {

--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -98,7 +98,8 @@ func safeDialer(config EsiParserConfig) *net.Dialer {
 			}
 			ip := net.ParseIP(host)
 			if ip == nil {
-				return fmt.Errorf("dial address is not an IP: %s", host)
+				// This should not happen - Control receives resolved IP:port
+				return fmt.Errorf("internal error: dial address expected to be IP but got: %s", host)
 			}
 			if config.BlockPrivateIPs && isPrivateOrReservedIP(ip) {
 				return fmt.Errorf("blocked dial to private/reserved ip: %s", ip)

--- a/mesi/fetchUrl_test.go
+++ b/mesi/fetchUrl_test.go
@@ -997,9 +997,62 @@ func TestSSRFDialBlocksPrivateIP(t *testing.T) {
 }
 
 func TestSSRFDialAllowsPublicIP(t *testing.T) {
-	// Note: This test requires network access and example.com to be reachable
-	// It may fail in isolated test environments
-	t.Skip("requires network access to public IP")
+	// Test that the safeDialer Control callback allows public IPs
+	config := EsiParserConfig{
+		BlockPrivateIPs: true,
+	}
+
+	dialer := safeDialer(config)
+
+	// Test with a public IP (8.8.8.8 - Google DNS)
+	// The Control callback should allow this (return nil)
+	err := dialer.Control("tcp", "8.8.8.8:80", nil)
+	if err != nil {
+		t.Errorf("expected public IP 8.8.8.8 to be allowed, got error: %v", err)
+	}
+
+	// Test with another public IP (1.1.1.1 - Cloudflare DNS)
+	err = dialer.Control("tcp", "1.1.1.1:443", nil)
+	if err != nil {
+		t.Errorf("expected public IP 1.1.1.1 to be allowed, got error: %v", err)
+	}
+
+	// Verify that private IPs are still blocked
+	err = dialer.Control("tcp", "127.0.0.1:80", nil)
+	if err == nil {
+		t.Error("expected private IP 127.0.0.1 to be blocked")
+	}
+
+	err = dialer.Control("tcp", "10.0.0.1:80", nil)
+	if err == nil {
+		t.Error("expected private IP 10.0.0.1 to be blocked")
+	}
+}
+
+func TestSSRFDialerWithBlockPrivateIPsDisabled(t *testing.T) {
+	// When BlockPrivateIPs=false, all IPs should be allowed
+	config := EsiParserConfig{
+		BlockPrivateIPs: false,
+	}
+
+	dialer := safeDialer(config)
+
+	// Private IPs should be allowed when BlockPrivateIPs=false
+	err := dialer.Control("tcp", "127.0.0.1:80", nil)
+	if err != nil {
+		t.Errorf("expected private IP to be allowed when BlockPrivateIPs=false, got: %v", err)
+	}
+
+	err = dialer.Control("tcp", "10.0.0.1:80", nil)
+	if err != nil {
+		t.Errorf("expected private IP to be allowed when BlockPrivateIPs=false, got: %v", err)
+	}
+
+	// Public IPs should also be allowed
+	err = dialer.Control("tcp", "8.8.8.8:80", nil)
+	if err != nil {
+		t.Errorf("expected public IP to be allowed when BlockPrivateIPs=false, got: %v", err)
+	}
 }
 
 func TestNewSSRFSafeTransport(t *testing.T) {

--- a/mesi/fetchUrl_test.go
+++ b/mesi/fetchUrl_test.go
@@ -522,20 +522,17 @@ func TestFetchConcurrentContextCancellation(t *testing.T) {
 }
 
 func TestIsURLSafe_BlocksPrivateIPs(t *testing.T) {
+	// Note: isURLSafe no longer checks private IPs at validation time.
+	// Private IP checking is now done at dial time via safeDialer.
+	// See TestSSRFDialBlocksPrivateIP for dial-time tests.
 	tests := []struct {
-		name      string
-		url       string
-		wantErr   bool
-		errSubstr string
+		name string
+		url  string
 	}{
-		{"localhost", "http://localhost/test", true, "private/reserved ip"},
-		{"127.0.0.1", "http://127.0.0.1/test", true, "private/reserved ip"},
-		{"10.0.0.1", "http://10.0.0.1/test", true, "private/reserved ip"},
-		{"172.16.0.1", "http://172.16.0.1/test", true, "private/reserved ip"},
-		{"192.168.1.1", "http://192.168.1.1/test", true, "private/reserved ip"},
-		{"169.254.1.1", "http://169.254.1.1/test", true, "private/reserved ip"},
-		{"0.0.0.0", "http://0.0.0.0/test", true, "private/reserved ip"},
-		{"public IP", "http://8.8.8.8/test", false, ""},
+		{"localhost", "http://localhost/test"},
+		{"127.0.0.1", "http://127.0.0.1/test"},
+		{"10.0.0.1", "http://10.0.0.1/test"},
+		{"public IP", "http://8.8.8.8/test"},
 	}
 
 	config := EsiParserConfig{
@@ -545,16 +542,10 @@ func TestIsURLSafe_BlocksPrivateIPs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := isURLSafe(tt.url, config)
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("expected error containing %q, got nil", tt.errSubstr)
-				} else if !strings.Contains(err.Error(), tt.errSubstr) {
-					t.Errorf("error %q does not contain %q", err.Error(), tt.errSubstr)
-				}
-			} else {
-				if err != nil {
-					t.Errorf("unexpected error: %v", err)
-				}
+			// isURLSafe should NOT return error for private IPs anymore
+			// (check is now at dial time)
+			if err != nil {
+				t.Errorf("isURLSafe should not check private IPs, got error: %v", err)
 			}
 		})
 	}
@@ -701,8 +692,9 @@ func TestSingleFetchUrlSSRFValidation(t *testing.T) {
 	if err == nil {
 		t.Error("expected SSRF error for private IP")
 	}
-	if !strings.Contains(err.Error(), "ssrf validation failed") {
-		t.Errorf("expected SSRF validation error, got: %v", err)
+	// Error now comes from dialer, not from isURLSafe validation
+	if !strings.Contains(err.Error(), "blocked dial to private/reserved ip") {
+		t.Errorf("expected dial-time SSRF error, got: %v", err)
 	}
 }
 
@@ -973,5 +965,64 @@ func TestFetchWithCache_EsiResponse(t *testing.T) {
 	}
 	if callCount != 1 {
 		t.Fatalf("expected 0 HTTP calls (cached), got %d", callCount)
+	}
+}
+
+func TestSSRFDialBlocksPrivateIP(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer server.Close()
+
+	// Create config with BlockPrivateIPs=true
+	config := EsiParserConfig{
+		DefaultUrl:      "http://127.0.0.1/",
+		MaxDepth:        1,
+		Timeout:         2 * time.Second,
+		BlockPrivateIPs: true,
+		Logger:          DiscardLogger{},
+	}
+
+	// Try to fetch from the test server
+	// The test server binds to 127.0.0.1 which is a private IP
+	// With BlockPrivateIPs=true, this should fail at dial time
+	_, _, err := singleFetchUrlWithContext(server.URL, config, context.Background())
+	if err == nil {
+		t.Fatal("expected error when fetching from private IP with BlockPrivateIPs=true, got nil")
+	}
+	if !contains(err.Error(), "blocked dial to private/reserved ip") {
+		t.Errorf("expected 'blocked dial' error, got: %v", err)
+	}
+}
+
+func TestSSRFDialAllowsPublicIP(t *testing.T) {
+	// Note: This test requires network access and example.com to be reachable
+	// It may fail in isolated test environments
+	t.Skip("requires network access to public IP")
+}
+
+func TestNewSSRFSafeTransport(t *testing.T) {
+	config := EsiParserConfig{
+		BlockPrivateIPs: true,
+	}
+
+	transport := NewSSRFSafeTransport(config)
+	if transport == nil {
+		t.Fatal("NewSSRFSafeTransport returned nil")
+	}
+
+	// Verify the transport has the correct DialContext
+	if transport.DialContext == nil {
+		t.Fatal("transport.DialContext is nil")
+	}
+
+	// Test with BlockPrivateIPs=false
+	config2 := EsiParserConfig{
+		BlockPrivateIPs: false,
+	}
+	transport2 := NewSSRFSafeTransport(config2)
+	if transport2 == nil {
+		t.Fatal("NewSSRFSafeTransport returned nil for BlockPrivateIPs=false")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #104 - SSRF bypass via DNS rebinding attack.

## Problem

`isURLSafe()` used `net.LookupIP()` to validate URLs, but `http.Client.Do()` performs its own independent DNS lookup when dialing. This TOCTOU (time-of-check/time-of-use) gap allows attackers to bypass `BlockPrivateIPs` protection by controlling DNS responses.

## Solution

- **Remove** `net.LookupIP` from `isURLSafe()` - validation no longer checks private IPs
- **Add** `safeDialer()` with `Control` callback that blocks connections to private/reserved IPs at **dial time**
- **Export** `NewSSRFSafeTransport()` helper for users with custom `HTTPClient`
- **Update** `singleFetchUrlWithContext()` to use safe transport by default

## Changes

- `mesi/fetchUrl.go`: Refactored `isURLSafe()`, added `safeDialer()` and `NewSSRFSafeTransport()`
- `mesi/fetchUrl_test.go`: Added `TestSSRFDialBlocksPrivateIP`, `TestNewSSRFSafeTransport`, updated existing tests

## Testing

- All existing tests pass
- New tests verify dial-time SSRF protection works correctly
- `TestSSRFDialBlocksPrivateIP`: Confirms private IPs are blocked at dial time
- `TestNewSSRFSafeTransport`: Verifies exported helper works correctly

## Migration

Users with custom `HTTPClient` should update to use `NewSSRFSafeTransport()`:

```go
client := &http.Client{
    Transport: mesi.NewSSRFSafeTransport(config),
    Timeout:   config.Timeout,
}
```

## Security Impact

**Severity**: Critical  
**Category**: SSRF

Prevents DNS rebinding attacks where attacker alternates DNS responses between public IP (passes validation) and private IP (used at dial time).