### PR TITLE
fix(mesi): filter IPv6 private/reserved addresses in SSRF guard (issue #105)

### DIFF
--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -15,6 +15,14 @@ import (
 	"time"
 )
 
+var (
+	_, cgnatCIDR, _       = net.ParseCIDR("100.64.0.0/10")
+	_, benchmarkCIDR, _   = net.ParseCIDR("198.18.0.0/15")
+	_, reserved240CIDR, _ = net.ParseCIDR("240.0.0.0/4")
+	_, documentationCIDR, _ = net.ParseCIDR("2001:db8::/32")
+	_, nat64CIDR, _        = net.ParseCIDR("64:ff9b::/96")
+)
+
 func IsEsiResponse(response *http.Response) bool {
 	header := strings.ToLower(response.Header.Get("Edge-control"))
 
@@ -69,7 +77,8 @@ func isPrivateOrReservedIP(ip net.IP) bool {
 		return true
 	}
 
-	if v4 := ip.To4(); v4 != nil {
+	v4 := ip.To4()
+	if v4 != nil {
 		ip = v4
 	}
 
@@ -78,19 +87,12 @@ func isPrivateOrReservedIP(ip net.IP) bool {
 		return true
 	}
 
-	if v4 := ip.To4(); v4 != nil {
-		_, cgnat, _ := net.ParseCIDR("100.64.0.0/10")
-		_, benchmark, _ := net.ParseCIDR("198.18.0.0/15")
-		_, reserved240, _ := net.ParseCIDR("240.0.0.0/4")
-		if cgnat.Contains(v4) || benchmark.Contains(v4) || reserved240.Contains(v4) {
+	if v4 != nil {
+		if cgnatCIDR.Contains(v4) || benchmarkCIDR.Contains(v4) || reserved240CIDR.Contains(v4) {
 			return true
 		}
-	}
-
-	if ip.To4() == nil {
-		_, documentation, _ := net.ParseCIDR("2001:db8::/32")
-		_, nat64, _ := net.ParseCIDR("64:ff9b::/96")
-		if documentation.Contains(ip) || nat64.Contains(ip) {
+	} else {
+		if documentationCIDR.Contains(ip) || nat64CIDR.Contains(ip) {
 			return true
 		}
 	}

--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -65,25 +65,37 @@ func isURLSafe(requestedURL string, config EsiParserConfig) error {
 }
 
 func isPrivateOrReservedIP(ip net.IP) bool {
-	privateBlocks := []string{
-		"10.0.0.0/8",
-		"172.16.0.0/12",
-		"192.168.0.0/16",
-		"127.0.0.0/8",
-		"169.254.0.0/16",
-		"0.0.0.0/8",
-		"224.0.0.0/4",
-		"240.0.0.0/4",
+	if ip == nil {
+		return true
 	}
 
-	for _, block := range privateBlocks {
-		_, cidr, _ := net.ParseCIDR(block)
-		if cidr.Contains(ip) {
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() || ip.IsUnspecified() || ip.IsPrivate() {
+		return true
+	}
+
+	if v4 := ip.To4(); v4 != nil {
+		_, cgnat, _ := net.ParseCIDR("100.64.0.0/10")
+		_, benchmark, _ := net.ParseCIDR("198.18.0.0/15")
+		_, reserved240, _ := net.ParseCIDR("240.0.0.0/4")
+		if cgnat.Contains(v4) || benchmark.Contains(v4) || reserved240.Contains(v4) {
 			return true
 		}
 	}
 
-	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsUnspecified()
+	if ip.To4() == nil {
+		_, documentation, _ := net.ParseCIDR("2001:db8::/32")
+		_, nat64, _ := net.ParseCIDR("64:ff9b::/96")
+		if documentation.Contains(ip) || nat64.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // safeDialer returns a net.Dialer with a Control callback that blocks

--- a/mesi/fetchUrl_test.go
+++ b/mesi/fetchUrl_test.go
@@ -734,6 +734,20 @@ func TestIsPrivateOrReservedIP(t *testing.T) {
 		{"reserved", "240.0.0.1", true},
 		{"public", "8.8.8.8", false},
 		{"public 2", "1.1.1.1", false},
+		{"ipv6 loopback", "::1", true},
+		{"ipv6 ULA fd00", "fd00::1", true},
+		{"ipv6 ULA fc00", "fc00::1", true},
+		{"ipv6 link-local", "fe80::1", true},
+		{"ipv6 unspecified", "::", true},
+		{"ipv4-mapped loopback", "::ffff:127.0.0.1", true},
+		{"ipv4-mapped private", "::ffff:10.0.0.1", true},
+		{"ipv6 documentation", "2001:db8::1", true},
+		{"ipv6 multicast", "ff02::1", true},
+		{"nat64", "64:ff9b::8.8.8.8", true},
+		{"cgnat", "100.64.0.1", true},
+		{"benchmark", "198.18.0.1", true},
+		{"public ipv6", "2606:4700:4700::1111", false},
+		{"public ipv6 google", "2001:4860:4860::8888", false},
 	}
 
 	for _, tt := range tests {

--- a/mesi/fetchUrl_test.go
+++ b/mesi/fetchUrl_test.go
@@ -1093,3 +1093,54 @@ func TestNewSSRFSafeTransport(t *testing.T) {
 		t.Fatal("NewSSRFSafeTransport returned nil for BlockPrivateIPs=false")
 	}
 }
+
+func TestSSRFBlocksIPv6Loopback(t *testing.T) {
+	config := EsiParserConfig{
+		DefaultUrl:      "http://example.com/",
+		MaxDepth:        1,
+		Timeout:         1 * time.Second,
+		BlockPrivateIPs: true,
+		Logger:          DiscardLogger{},
+	}
+
+	html := `<html><body><esi:include src="http://[::1]/test"/></body></html>`
+	result := MESIParse(html, config)
+
+	if !strings.Contains(result, "blocked dial to private/reserved ip") {
+		t.Errorf("expected SSRF block for IPv6 loopback, got: %q", result)
+	}
+}
+
+func TestSSRFBlocksIPv6ULA(t *testing.T) {
+	config := EsiParserConfig{
+		DefaultUrl:      "http://example.com/",
+		MaxDepth:        1,
+		Timeout:         1 * time.Second,
+		BlockPrivateIPs: true,
+		Logger:          DiscardLogger{},
+	}
+
+	html := `<html><body><esi:include src="http://[fd00::1]/test"/></body></html>`
+	result := MESIParse(html, config)
+
+	if !strings.Contains(result, "blocked dial to private/reserved ip") {
+		t.Errorf("expected SSRF block for IPv6 ULA, got: %q", result)
+	}
+}
+
+func TestSSRFBlocksIPv4MappedIPv6(t *testing.T) {
+	config := EsiParserConfig{
+		DefaultUrl:      "http://example.com/",
+		MaxDepth:        1,
+		Timeout:         1 * time.Second,
+		BlockPrivateIPs: true,
+		Logger:          DiscardLogger{},
+	}
+
+	html := `<html><body><esi:include src="http://[::ffff:127.0.0.1]/test"/></body></html>`
+	result := MESIParse(html, config)
+
+	if !strings.Contains(result, "blocked dial to private/reserved ip") {
+		t.Errorf("expected SSRF block for IPv4-mapped IPv6, got: %q", result)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes SSRF vulnerability where IPv6 private/reserved addresses were not filtered by the SSRF guard.

## Changes

- Replace hand-maintained IPv4 CIDR list with Go 1.17+ `IP.IsPrivate()`
- Add IPv6 support:
  - ULA (`fc00::/7`) - IPv6 equivalent of RFC1918
  - Loopback (`::1`)
  - Link-local (`fe80::/10`)
  - Documentation (`2001:db8::/32`)
  - NAT64 (`64:ff9b::/96`)
  - Multicast (`ff00::/8`)
- Handle IPv4-mapped IPv6 addresses (`::ffff:0:0/96`)
- Add CGNAT (`100.64.0.0/10`) and benchmark (`198.18.0.0/15`) IPv4 ranges
- Add 14 new test cases covering all IPv6 scenarios

## Security Impact

Before this fix, URLs like:
- `http://[::1]/` - IPv6 loopback
- `http://[fd00::1]/` - IPv6 ULA (private)
- `http://[::ffff:127.0.0.1]/` - IPv4-mapped loopback

...could bypass the SSRF guard and access internal network resources.

Fixes #105