### PR TITLE
[mesi] Fix AllowedHosts port bug and add private-IP bypass opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,23 @@ When set, specifies a whitelist of allowed hostnames for ESI includes. If define
 
 This is useful when you want to restrict ESI includes to a specific set of trusted domains while still blocking private IP ranges.
 
+**AllowPrivateIPsForAllowedHosts**
+
+When set to `true`, hosts in `AllowedHosts` are allowed to resolve to private/reserved IP addresses, bypassing the `BlockPrivateIPs` check.
+
+⚠️ **Security Warning:** This creates a potential SSRF vector if an attacker can control DNS for a host in `AllowedHosts`. Only use in trusted environments where you control DNS resolution (e.g., internal reverse proxy setups).
+
+Default: `false` (private IPs always blocked regardless of `AllowedHosts`)
+
+Example:
+```go
+config := mesi.EsiParserConfig{
+    BlockPrivateIPs:                true,
+    AllowedHosts:                   []string{"internal.local"},
+    AllowPrivateIPsForAllowedHosts: true,
+}
+```
+
 **MaxResponseSize**
 
 Sets the maximum allowed size for HTTP response bodies (in bytes) when fetching ESI includes. Helps prevent OOM attacks from malicious or compromised upstream servers returning arbitrarily large responses.

--- a/docs/specs/2026-05-03-allowed-hosts-port-fix-design.md
+++ b/docs/specs/2026-05-03-allowed-hosts-port-fix-design.md
@@ -1,0 +1,201 @@
+# Fix #106: AllowedHosts Port Bug + Private-IP Bypass Opt-In
+
+## Problem
+
+Two bugs in `AllowedHosts` logic in `mesi/fetchUrl.go`:
+
+### 1. Port Bug
+
+`parsedURL.Host` includes port (e.g., `example.com:8080`), so it doesn't match `example.com` in `AllowedHosts`:
+
+```go
+parsed.Host       = "example.com:8080"
+AllowedHosts[0]   = "example.com"
+// neither equality nor suffix match → false negative
+```
+
+Users with allowlist see their allowed hosts silently rejected when URLs contain ports.
+
+### 2. No Opt-In for Internal Proxy Setups
+
+Some deployments legitimately need to include from internal services (e.g., reverse proxy to `127.0.0.1:8080`). Currently there's no way to allow this while keeping `BlockPrivateIPs=true` for other hosts.
+
+## Solution
+
+### 1. Port Fix
+
+Use `parsedURL.Hostname()` instead of `parsedURL.Host` to strip port before comparison.
+
+### 2. Opt-In Flag
+
+Add `AllowPrivateIPsForAllowedHosts bool` field to `EsiParserConfig`. When `true`, hosts in `AllowedHosts` bypass the private-IP check.
+
+## Design
+
+### 1. New Config Field (parser.go)
+
+```go
+type EsiParserConfig struct {
+    // ... existing fields ...
+
+    // AllowPrivateIPsForAllowedHosts allows hosts in AllowedHosts to bypass
+    // the BlockPrivateIPs check.
+    //
+    // SECURITY WARNING: This creates a potential SSRF vector if an attacker
+    // can control DNS for a host in AllowedHosts. Only use in trusted environments
+    // where you control DNS resolution (e.g., internal reverse proxy setups).
+    //
+    // When true, requests to hosts in AllowedHosts will NOT be checked for
+    // private/reserved IP addresses at dial time.
+    //
+    // Default: false (private IPs always blocked regardless of AllowedHosts).
+    AllowPrivateIPsForAllowedHosts bool
+}
+```
+
+### 2. Port Fix in isURLSafe (fetchUrl.go)
+
+```go
+func isURLSafe(requestedURL string, config EsiParserConfig) error {
+    parsedURL, err := url.Parse(requestedURL)
+    if err != nil {
+        return errors.New("invalid url: " + err.Error())
+    }
+
+    host := parsedURL.Hostname() // CHANGED: was parsedURL.Host
+
+    // Relative URLs have no host and no scheme
+    if parsedURL.Scheme == "" && host == "" {
+        return nil
+    }
+
+    if host == "" {
+        return errors.New("url has no host")
+    }
+
+    if len(config.AllowedHosts) > 0 {
+        allowed := false
+        for _, allowedHost := range config.AllowedHosts {
+            if host == allowedHost || strings.HasSuffix(host, "."+allowedHost) {
+                allowed = true
+                break
+            }
+        }
+        if !allowed {
+            return errors.New("host not in allowed list: " + host)
+        }
+    }
+
+    return nil
+}
+```
+
+### 3. Helper Function (fetchUrl.go)
+
+```go
+// hostInAllowedHosts checks if a hostname matches any entry in AllowedHosts.
+// Matches exact hostnames and subdomains (e.g., "api.example.com" matches "example.com").
+func hostInAllowedHosts(host string, config EsiParserConfig) bool {
+    for _, allowed := range config.AllowedHosts {
+        if host == allowed || strings.HasSuffix(host, "."+allowed) {
+            return true
+        }
+    }
+    return false
+}
+```
+
+### 4. Modified Client Selection (fetchUrl.go)
+
+```go
+func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx context.Context) (string, bool, error) {
+    // ... existing code up to isURLSafe check ...
+
+    if err := isURLSafe(requestedURL, config); err != nil {
+        logger.Debug("fetch_ssrf_error", "url", requestedURL, "error", err.Error())
+        return "", false, errors.New("ssrf validation failed: " + err.Error())
+    }
+
+    parsed, _ := url.Parse(requestedURL)
+    
+    var client httpDoer
+    if config.HTTPClient != nil {
+        client = config.HTTPClient
+    } else if config.AllowPrivateIPsForAllowedHosts && hostInAllowedHosts(parsed.Hostname(), config) {
+        // Allowed host with private-IP bypass — use standard client
+        client = &http.Client{Timeout: config.Timeout}
+    } else {
+        // Use SSRF-safe transport
+        client = &http.Client{
+            Timeout:   config.Timeout,
+            Transport: NewSSRFSafeTransport(config),
+        }
+    }
+
+    // ... rest of existing code ...
+}
+```
+
+### 5. Update Godoc for AllowedHosts (parser.go)
+
+```go
+// AllowedHosts restricts ESI includes to specified domains.
+// Empty list allows all hosts (subject to BlockPrivateIPs).
+//
+// Examples:
+//   - ["example.com"] — allows example.com and *.example.com
+//   - ["internal.local", "api.trusted.com"] — allows multiple domains
+//
+// Note: AllowedHosts does NOT bypass BlockPrivateIPs by default.
+// Use AllowPrivateIPsForAllowedHosts to enable private-IP bypass for allowed hosts.
+AllowedHosts []string
+```
+
+## Testing Plan
+
+### Unit Tests
+
+1. **Port handling tests** (extend `TestIsURLSafe_AllowedHosts`):
+   ```go
+   {"allowed host with port", "http://example.com:8080/test", []string{"example.com"}, false},
+   {"allowed subdomain with port", "http://api.example.com:443/test", []string{"example.com"}, false},
+   {"port in allowed list", "http://example.com:8080/test", []string{"example.com:8080"}, true}, // should fail
+   ```
+
+2. **AllowPrivateIPsForAllowedHosts tests**:
+   ```go
+   func TestAllowPrivateIPsForAllowedHosts(t *testing.T) {
+       // Test that allowed host with private IP is blocked when flag is false
+       // Test that allowed host with private IP is allowed when flag is true
+   }
+   ```
+
+3. **Integration test**:
+   - Start test server on 127.0.0.1
+   - Configure `AllowedHosts: ["localhost"]`
+   - Verify request blocked with `AllowPrivateIPsForAllowedHosts=false`
+   - Verify request allowed with `AllowPrivateIPsForAllowedHosts=true`
+
+## Files to Modify
+
+1. `mesi/parser.go` — Add `AllowPrivateIPsForAllowedHosts` field, update godoc
+2. `mesi/fetchUrl.go` — Port fix, add `hostInAllowedHosts`, modify client selection
+3. `mesi/fetchUrl_test.go` — Add tests for port handling and opt-in flag
+4. `README.md` — Document new config option
+
+## Acceptance Criteria
+
+- [ ] `parsedURL.Hostname()` used instead of `parsedURL.Host`
+- [ ] `AllowPrivateIPsForAllowedHosts` field added to `EsiParserConfig`
+- [ ] Hosts in `AllowedHosts` bypass private-IP check when flag is `true`
+- [ ] Default behavior unchanged (private IPs blocked regardless of `AllowedHosts`)
+- [ ] Tests cover port handling and opt-in flag behavior
+- [ ] Godoc updated for `AllowedHosts` and new field
+- [ ] README updated with new config option
+
+## Security Considerations
+
+- **Default safe**: `AllowPrivateIPsForAllowedHosts=false` by default
+- **Explicit opt-in**: Users must consciously enable the bypass
+- **Documented risk**: Godoc clearly warns about SSRF vector
+- **Dial-time protection preserved**: Non-allowed hosts still protected by `safeDialer`

--- a/docs/specs/2026-05-03-allowed-hosts-port-fix-plan.md
+++ b/docs/specs/2026-05-03-allowed-hosts-port-fix-plan.md
@@ -1,0 +1,467 @@
+# AllowedHosts Port Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix port bug in AllowedHosts matching and add opt-in flag to bypass private-IP check for allowed hosts.
+
+**Architecture:** Use `parsedURL.Hostname()` instead of `parsedURL.Host` to strip port. Add `AllowPrivateIPsForAllowedHosts` config field. When enabled, hosts in AllowedHosts use standard HTTP client without SSRF-safe transport.
+
+**Tech Stack:** Go 1.x, net/url, net/http
+
+---
+
+## File Structure
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `mesi/parser.go` | Modify | Add `AllowPrivateIPsForAllowedHosts` field to `EsiParserConfig` |
+| `mesi/fetchUrl.go` | Modify | Port fix in `isURLSafe`, add `hostInAllowedHosts` helper, modify client selection in `singleFetchUrlWithContext` |
+| `mesi/fetchUrl_test.go` | Modify | Add port handling tests, add opt-in flag tests |
+| `README.md` | Modify | Document new config option |
+
+---
+
+### Task 1: Add Config Field
+
+**Files:**
+- Modify: `mesi/parser.go:17-34`
+
+- [ ] **Step 1: Add `AllowPrivateIPsForAllowedHosts` field to `EsiParserConfig`**
+
+```go
+type EsiParserConfig struct {
+	Context               context.Context
+	DefaultUrl            string
+	MaxDepth              uint
+	Timeout               time.Duration
+	ParseOnHeader         bool
+	AllowedHosts          []string
+	BlockPrivateIPs       bool
+	AllowPrivateIPsForAllowedHosts bool // NEW: allows AllowedHosts to bypass private-IP check
+	MaxResponseSize       int64
+	MaxConcurrentRequests int
+	HTTPClient            *http.Client
+	Cache                 Cache
+	CacheTTL              time.Duration
+	CacheKeyFunc          CacheKeyFunc
+	Debug                 bool
+	Logger                Logger
+	requestSemaphore      chan struct{}
+}
+```
+
+- [ ] **Step 2: Run tests to verify no breakage**
+
+Run: `go test ./mesi/... -v -count=1`
+Expected: All tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mesi/parser.go
+git commit -m "feat(mesi): add AllowPrivateIPsForAllowedHosts config field"
+```
+
+---
+
+### Task 2: Write Port Handling Tests
+
+**Files:**
+- Modify: `mesi/fetchUrl_test.go:640-672`
+
+- [ ] **Step 1: Add port handling test cases to `TestIsURLSafe_AllowedHosts`**
+
+```go
+func TestIsURLSafe_AllowedHosts(t *testing.T) {
+	tests := []struct {
+		name         string
+		url          string
+		allowedHosts []string
+		wantErr      bool
+	}{
+		{"allowed exact", "http://example.com/test", []string{"example.com"}, false},
+		{"allowed subdomain", "http://api.example.com/test", []string{"example.com"}, false},
+		{"not allowed", "http://other.com/test", []string{"example.com"}, true},
+		{"multiple allowed", "http://foo.com/test", []string{"example.com", "foo.com"}, false},
+		{"empty allowed list", "http://example.com/test", []string{}, false},
+		// NEW: Port handling tests
+		{"allowed host with port", "http://example.com:8080/test", []string{"example.com"}, false},
+		{"allowed subdomain with port", "http://api.example.com:443/test", []string{"example.com"}, false},
+		{"not allowed with port", "http://other.com:8080/test", []string{"example.com"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := EsiParserConfig{
+				BlockPrivateIPs: true,
+				AllowedHosts:    tt.allowedHosts,
+			}
+			err := isURLSafe(tt.url, config)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./mesi/... -run TestIsURLSafe_AllowedHosts -v`
+Expected: FAIL - "allowed host with port" and "allowed subdomain with port" should fail
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mesi/fetchUrl_test.go
+git commit -m "test(mesi): add port handling test cases for AllowedHosts"
+```
+
+---
+
+### Task 3: Fix Port Bug in isURLSafe
+
+**Files:**
+- Modify: `mesi/fetchUrl.go:41-73`
+
+- [ ] **Step 1: Change `parsedURL.Host` to `parsedURL.Hostname()` in `isURLSafe`**
+
+```go
+func isURLSafe(requestedURL string, config EsiParserConfig) error {
+	parsedURL, err := url.Parse(requestedURL)
+	if err != nil {
+		return errors.New("invalid url: " + err.Error())
+	}
+
+	host := parsedURL.Hostname() // CHANGED: was parsedURL.Host
+
+	// Relative URLs have no host and no scheme
+	if parsedURL.Scheme == "" && host == "" {
+		return nil
+	}
+
+	if host == "" {
+		return errors.New("url has no host")
+	}
+
+	if len(config.AllowedHosts) > 0 {
+		allowed := false
+		for _, allowedHost := range config.AllowedHosts {
+			if host == allowedHost || strings.HasSuffix(host, "."+allowedHost) {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return errors.New("host not in allowed list: " + host)
+		}
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 2: Run tests to verify port tests pass**
+
+Run: `go test ./mesi/... -run TestIsURLSafe_AllowedHosts -v`
+Expected: PASS
+
+- [ ] **Step 3: Run all tests**
+
+Run: `go test ./mesi/... -v -count=1`
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mesi/fetchUrl.go
+git commit -m "fix(mesi): use Hostname() instead of Host in AllowedHosts check"
+```
+
+---
+
+### Task 4: Add hostInAllowedHosts Helper Function
+
+**Files:**
+- Modify: `mesi/fetchUrl.go` (add after `isPrivateOrReservedIP` function)
+
+- [ ] **Step 1: Add `hostInAllowedHosts` helper function**
+
+```go
+// hostInAllowedHosts checks if a hostname matches any entry in AllowedHosts.
+// Matches exact hostnames and subdomains (e.g., "api.example.com" matches "example.com").
+func hostInAllowedHosts(host string, config EsiParserConfig) bool {
+	for _, allowed := range config.AllowedHosts {
+		if host == allowed || strings.HasSuffix(host, "."+allowed) {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 2: Run tests to verify no breakage**
+
+Run: `go test ./mesi/... -v -count=1`
+Expected: All tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mesi/fetchUrl.go
+git commit -m "feat(mesi): add hostInAllowedHosts helper function"
+```
+
+---
+
+### Task 5: Write AllowPrivateIPsForAllowedHosts Tests
+
+**Files:**
+- Modify: `mesi/fetchUrl_test.go` (add after `TestIsURLSafe_AllowedHosts`)
+
+- [ ] **Step 1: Add test for `AllowPrivateIPsForAllowedHosts` flag**
+
+```go
+func TestAllowPrivateIPsForAllowedHosts(t *testing.T) {
+	// Start a test server on 127.0.0.1 (private IP)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("test response"))
+	}))
+	defer server.Close()
+
+	serverURL, _ := url.Parse(server.URL)
+	serverHost := serverURL.Hostname()
+
+	t.Run("blocked when flag is false", func(t *testing.T) {
+		config := EsiParserConfig{
+			BlockPrivateIPs:                true,
+			AllowPrivateIPsForAllowedHosts: false,
+			AllowedHosts:                   []string{serverHost},
+			Timeout:                        5 * time.Second,
+		}
+
+		_, _, err := singleFetchUrlWithContext(server.URL, config, context.Background())
+		if err == nil {
+			t.Error("expected error for private IP when flag is false")
+		}
+	})
+
+	t.Run("allowed when flag is true", func(t *testing.T) {
+		config := EsiParserConfig{
+			BlockPrivateIPs:                true,
+			AllowPrivateIPsForAllowedHosts: true,
+			AllowedHosts:                   []string{serverHost},
+			Timeout:                        5 * time.Second,
+		}
+
+		result, _, err := singleFetchUrlWithContext(server.URL, config, context.Background())
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if result != "test response" {
+			t.Errorf("expected 'test response', got: %q", result)
+		}
+	})
+
+	t.Run("blocked when host not in AllowedHosts", func(t *testing.T) {
+		config := EsiParserConfig{
+			BlockPrivateIPs:                true,
+			AllowPrivateIPsForAllowedHosts: true,
+			AllowedHosts:                   []string{"other.example.com"},
+			Timeout:                        5 * time.Second,
+		}
+
+		_, _, err := singleFetchUrlWithContext(server.URL, config, context.Background())
+		if err == nil {
+			t.Error("expected error for host not in AllowedHosts")
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./mesi/... -run TestAllowPrivateIPsForAllowedHosts -v`
+Expected: FAIL
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mesi/fetchUrl_test.go
+git commit -m "test(mesi): add tests for AllowPrivateIPsForAllowedHosts flag"
+```
+
+---
+
+### Task 6: Implement AllowPrivateIPsForAllowedHosts in Client Selection
+
+**Files:**
+- Modify: `mesi/fetchUrl.go:181-195`
+
+- [ ] **Step 1: Modify client selection logic in `singleFetchUrlWithContext`**
+
+Replace the client creation section with:
+
+```go
+	var client httpDoer
+	if config.HTTPClient != nil {
+		client = config.HTTPClient
+	} else if config.AllowPrivateIPsForAllowedHosts && hostInAllowedHosts(parsed.Hostname(), config) {
+		// Allowed host with private-IP bypass opt-in - use standard client
+		client = &http.Client{Timeout: config.Timeout}
+	} else {
+		// Use SSRF-safe transport with dial-time private IP blocking
+		transport := NewSSRFSafeTransport(config)
+		client = &http.Client{
+			Timeout:   config.Timeout,
+			Transport: transport,
+		}
+	}
+```
+
+- [ ] **Step 2: Run tests to verify flag tests pass**
+
+Run: `go test ./mesi/... -run TestAllowPrivateIPsForAllowedHosts -v`
+Expected: PASS
+
+- [ ] **Step 3: Run all tests**
+
+Run: `go test ./mesi/... -v -count=1`
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mesi/fetchUrl.go
+git commit -m "feat(mesi): implement AllowPrivateIPsForAllowedHosts bypass"
+```
+
+---
+
+### Task 7: Update Godoc
+
+**Files:**
+- Modify: `mesi/parser.go:17-34`
+
+- [ ] **Step 1: Add documentation comments**
+
+```go
+type EsiParserConfig struct {
+	Context               context.Context
+	DefaultUrl            string
+	MaxDepth              uint
+	Timeout               time.Duration
+	ParseOnHeader         bool
+	// AllowedHosts restricts ESI includes to specified domains.
+	// Empty list allows all hosts (subject to BlockPrivateIPs).
+	//
+	// Note: AllowedHosts does NOT bypass BlockPrivateIPs by default.
+	// Use AllowPrivateIPsForAllowedHosts to enable private-IP bypass.
+	AllowedHosts []string
+	BlockPrivateIPs bool
+	// AllowPrivateIPsForAllowedHosts allows hosts in AllowedHosts to bypass
+	// the BlockPrivateIPs check.
+	//
+	// SECURITY WARNING: This creates a potential SSRF vector if an attacker
+	// can control DNS for a host in AllowedHosts. Only use in trusted environments.
+	//
+	// Default: false (private IPs always blocked regardless of AllowedHosts).
+	AllowPrivateIPsForAllowedHosts bool
+	MaxResponseSize       int64
+	MaxConcurrentRequests int
+	HTTPClient            *http.Client
+	Cache                 Cache
+	CacheTTL              time.Duration
+	CacheKeyFunc          CacheKeyFunc
+	Debug                 bool
+	Logger                Logger
+	requestSemaphore      chan struct{}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test ./mesi/... -v -count=1`
+Expected: All tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mesi/parser.go
+git commit -m "docs(mesi): add godoc for AllowedHosts and AllowPrivateIPsForAllowedHosts"
+```
+
+---
+
+### Task 8: Update README
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add documentation for `AllowPrivateIPsForAllowedHosts`**
+
+Add after the AllowedHosts section:
+
+```markdown
+**AllowPrivateIPsForAllowedHosts**
+
+When set to `true`, hosts in `AllowedHosts` are allowed to resolve to private/reserved IP addresses, bypassing the `BlockPrivateIPs` check.
+
+Security Warning: This creates a potential SSRF vector if an attacker can control DNS for a host in AllowedHosts. Only use in trusted environments where you control DNS resolution.
+
+Use case: Internal reverse proxy setups where ESI includes need to fetch from internal services.
+
+Default: `false`
+
+Example:
+config := mesi.EsiParserConfig{
+    BlockPrivateIPs:                true,
+    AllowedHosts:                   []string{"internal.local"},
+    AllowPrivateIPsForAllowedHosts: true,
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document AllowPrivateIPsForAllowedHosts config option"
+```
+
+---
+
+### Task 9: Final Verification
+
+- [ ] **Step 1: Run all tests**
+
+Run: `go test ./... -v -count=1`
+Expected: All tests pass
+
+- [ ] **Step 2: Run linter**
+
+Run: `go vet ./...`
+Expected: No issues
+
+- [ ] **Step 3: Verify godoc**
+
+Run: `go doc -all ./mesi/ | grep -A 10 "AllowPrivateIPsForAllowedHosts"`
+Expected: Documentation appears
+
+---
+
+## Acceptance Criteria
+
+- [ ] `parsedURL.Hostname()` used instead of `parsedURL.Host`
+- [ ] `AllowPrivateIPsForAllowedHosts` field added to `EsiParserConfig`
+- [ ] Hosts in `AllowedHosts` bypass private-IP check when flag is `true`
+- [ ] Default behavior unchanged (private IPs blocked regardless of `AllowedHosts`)
+- [ ] Tests cover port handling and opt-in flag behavior
+- [ ] Godoc updated for `AllowedHosts` and new field
+- [ ] README updated with new config option

--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -44,7 +44,7 @@ func isURLSafe(requestedURL string, config EsiParserConfig) error {
 		return errors.New("invalid url: " + err.Error())
 	}
 
-	host := parsedURL.Host
+	host := parsedURL.Hostname()
 
 	// Relative URLs have no host and no scheme - they will be resolved against DefaultUrl
 	if parsedURL.Scheme == "" && host == "" {

--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -192,6 +192,9 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 	var client httpDoer
 	if config.HTTPClient != nil {
 		client = config.HTTPClient
+	} else if config.AllowPrivateIPsForAllowedHosts && hostInAllowedHosts(parsed.Hostname(), config) {
+		// Allowed host with private-IP bypass opt-in - use standard client without SSRF protection.
+		client = &http.Client{Timeout: config.Timeout}
 	} else {
 		transport := NewSSRFSafeTransport(config)
 		client = &http.Client{

--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -100,6 +100,17 @@ func isPrivateOrReservedIP(ip net.IP) bool {
 	return false
 }
 
+// hostInAllowedHosts checks if a hostname matches any entry in AllowedHosts.
+// Matches exact hostnames and subdomains (e.g., "api.example.com" matches "example.com").
+func hostInAllowedHosts(host string, config EsiParserConfig) bool {
+	for _, allowed := range config.AllowedHosts {
+		if host == allowed || strings.HasSuffix(host, "."+allowed) {
+			return true
+		}
+	}
+	return false
+}
+
 // safeDialer returns a net.Dialer with a Control callback that blocks
 // connections to private/reserved IP addresses at dial time.
 // This prevents SSRF via DNS rebinding attacks (TOCTOU between validation and dial).

--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -16,11 +16,11 @@ import (
 )
 
 var (
-	_, cgnatCIDR, _       = net.ParseCIDR("100.64.0.0/10")
-	_, benchmarkCIDR, _   = net.ParseCIDR("198.18.0.0/15")
-	_, reserved240CIDR, _ = net.ParseCIDR("240.0.0.0/4")
+	_, cgnatCIDR, _         = net.ParseCIDR("100.64.0.0/10")
+	_, benchmarkCIDR, _     = net.ParseCIDR("198.18.0.0/15")
+	_, reserved240CIDR, _   = net.ParseCIDR("240.0.0.0/4")
 	_, documentationCIDR, _ = net.ParseCIDR("2001:db8::/32")
-	_, nat64CIDR, _        = net.ParseCIDR("64:ff9b::/96")
+	_, nat64CIDR, _         = net.ParseCIDR("64:ff9b::/96")
 )
 
 func IsEsiResponse(response *http.Response) bool {

--- a/mesi/fetchUrl_test.go
+++ b/mesi/fetchUrl_test.go
@@ -679,7 +679,7 @@ func TestIsURLSafe_AllowedHosts(t *testing.T) {
 func TestAllowPrivateIPsForAllowedHosts(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("test response"))
+		_, _ = w.Write([]byte("test response"))
 	}))
 	defer server.Close()
 

--- a/mesi/fetchUrl_test.go
+++ b/mesi/fetchUrl_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -673,6 +674,62 @@ func TestIsURLSafe_AllowedHosts(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAllowPrivateIPsForAllowedHosts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("test response"))
+	}))
+	defer server.Close()
+
+	serverURL, _ := url.Parse(server.URL)
+	serverHost := serverURL.Hostname()
+
+	t.Run("blocked when flag is false", func(t *testing.T) {
+		config := EsiParserConfig{
+			BlockPrivateIPs:                true,
+			AllowPrivateIPsForAllowedHosts: false,
+			AllowedHosts:                   []string{serverHost},
+			Timeout:                        5 * time.Second,
+		}
+
+		_, _, err := singleFetchUrlWithContext(server.URL, config, context.Background())
+		if err == nil {
+			t.Error("expected error for private IP when flag is false")
+		}
+	})
+
+	t.Run("allowed when flag is true", func(t *testing.T) {
+		config := EsiParserConfig{
+			BlockPrivateIPs:                true,
+			AllowPrivateIPsForAllowedHosts: true,
+			AllowedHosts:                   []string{serverHost},
+			Timeout:                        5 * time.Second,
+		}
+
+		result, _, err := singleFetchUrlWithContext(server.URL, config, context.Background())
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if result != "test response" {
+			t.Errorf("expected 'test response', got: %q", result)
+		}
+	})
+
+	t.Run("blocked when host not in AllowedHosts", func(t *testing.T) {
+		config := EsiParserConfig{
+			BlockPrivateIPs:                true,
+			AllowPrivateIPsForAllowedHosts: true,
+			AllowedHosts:                   []string{"other.example.com"},
+			Timeout:                        5 * time.Second,
+		}
+
+		_, _, err := singleFetchUrlWithContext(server.URL, config, context.Background())
+		if err == nil {
+			t.Error("expected error for host not in AllowedHosts")
+		}
+	})
 }
 
 func TestIsURLSafe_Disabled(t *testing.T) {

--- a/mesi/fetchUrl_test.go
+++ b/mesi/fetchUrl_test.go
@@ -649,6 +649,10 @@ func TestIsURLSafe_AllowedHosts(t *testing.T) {
 		{"not allowed", "http://other.com/test", []string{"example.com"}, true},
 		{"multiple allowed", "http://foo.com/test", []string{"example.com", "foo.com"}, false},
 		{"empty allowed list", "http://example.com/test", []string{}, false},
+		// Port handling tests
+		{"allowed host with port", "http://example.com:8080/test", []string{"example.com"}, false},
+		{"allowed subdomain with port", "http://api.example.com:443/test", []string{"example.com"}, false},
+		{"not allowed with port", "http://other.com:8080/test", []string{"example.com"}, true},
 	}
 
 	for _, tt := range tests {

--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -20,9 +20,21 @@ type EsiParserConfig struct {
 	MaxDepth              uint
 	Timeout               time.Duration
 	ParseOnHeader         bool
+	// AllowedHosts restricts ESI includes to specified domains.
+	// Empty list allows all hosts (subject to BlockPrivateIPs).
+	//
+	// Note: AllowedHosts does NOT bypass BlockPrivateIPs by default.
+	// Use AllowPrivateIPsForAllowedHosts to enable private-IP bypass.
 	AllowedHosts                    []string
 	BlockPrivateIPs                 bool
-	AllowPrivateIPsForAllowedHosts bool // allows AllowedHosts to bypass private-IP check
+	// AllowPrivateIPsForAllowedHosts allows hosts in AllowedHosts to bypass
+	// the BlockPrivateIPs check.
+	//
+	// SECURITY WARNING: This creates a potential SSRF vector if an attacker
+	// can control DNS for a host in AllowedHosts. Only use in trusted environments.
+	//
+	// Default: false (private IPs always blocked regardless of AllowedHosts).
+	AllowPrivateIPsForAllowedHosts bool
 	MaxResponseSize       int64         // 0 = unlimited, default 10MB
 	MaxConcurrentRequests int           // 0 = unlimited (backward compatible)
 	HTTPClient            *http.Client  // shared client for connection pooling, nil = create per request

--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -15,18 +15,18 @@ type Response struct {
 }
 
 type EsiParserConfig struct {
-	Context               context.Context
-	DefaultUrl            string
-	MaxDepth              uint
-	Timeout               time.Duration
-	ParseOnHeader         bool
+	Context       context.Context
+	DefaultUrl    string
+	MaxDepth      uint
+	Timeout       time.Duration
+	ParseOnHeader bool
 	// AllowedHosts restricts ESI includes to specified domains.
 	// Empty list allows all hosts (subject to BlockPrivateIPs).
 	//
 	// Note: AllowedHosts does NOT bypass BlockPrivateIPs by default.
 	// Use AllowPrivateIPsForAllowedHosts to enable private-IP bypass.
-	AllowedHosts                    []string
-	BlockPrivateIPs                 bool
+	AllowedHosts    []string
+	BlockPrivateIPs bool
 	// AllowPrivateIPsForAllowedHosts allows hosts in AllowedHosts to bypass
 	// the BlockPrivateIPs check.
 	//
@@ -35,15 +35,15 @@ type EsiParserConfig struct {
 	//
 	// Default: false (private IPs always blocked regardless of AllowedHosts).
 	AllowPrivateIPsForAllowedHosts bool
-	MaxResponseSize       int64         // 0 = unlimited, default 10MB
-	MaxConcurrentRequests int           // 0 = unlimited (backward compatible)
-	HTTPClient            *http.Client  // shared client for connection pooling, nil = create per request
-	Cache                 Cache         // nil = no caching (backward compatible)
-	CacheTTL              time.Duration // Default TTL for cached entries
-	CacheKeyFunc          CacheKeyFunc  // Custom cache key function (nil = DefaultCacheKey)
-	Debug                 bool          // Enable debug logging
-	Logger                Logger        // Custom logger (nil = DiscardLogger when Debug is false)
-	requestSemaphore      chan struct{} // semaphore for limiting HTTP requests
+	MaxResponseSize                int64         // 0 = unlimited, default 10MB
+	MaxConcurrentRequests          int           // 0 = unlimited (backward compatible)
+	HTTPClient                     *http.Client  // shared client for connection pooling, nil = create per request
+	Cache                          Cache         // nil = no caching (backward compatible)
+	CacheTTL                       time.Duration // Default TTL for cached entries
+	CacheKeyFunc                   CacheKeyFunc  // Custom cache key function (nil = DefaultCacheKey)
+	Debug                          bool          // Enable debug logging
+	Logger                         Logger        // Custom logger (nil = DiscardLogger when Debug is false)
+	requestSemaphore               chan struct{} // semaphore for limiting HTTP requests
 }
 
 func (c EsiParserConfig) getSemaphore() chan struct{} {

--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -20,8 +20,9 @@ type EsiParserConfig struct {
 	MaxDepth              uint
 	Timeout               time.Duration
 	ParseOnHeader         bool
-	AllowedHosts          []string
-	BlockPrivateIPs       bool
+	AllowedHosts                    []string
+	BlockPrivateIPs                 bool
+	AllowPrivateIPsForAllowedHosts bool // allows AllowedHosts to bypass private-IP check
 	MaxResponseSize       int64         // 0 = unlimited, default 10MB
 	MaxConcurrentRequests int           // 0 = unlimited (backward compatible)
 	HTTPClient            *http.Client  // shared client for connection pooling, nil = create per request


### PR DESCRIPTION
## Summary

- **Fix port bug:** use `parsedURL.Hostname()` instead of `parsedURL.Host` so that `AllowedHosts` matching works when URLs include ports (e.g. `http://example.com:8080/test` matches `example.com`)
- **Add `AllowPrivateIPsForAllowedHosts` opt-in flag:** when `true`, hosts in `AllowedHosts` bypass the `BlockPrivateIPs` check — needed for internal reverse proxy setups where allowed hosts legitimately resolve to private IPs
- Default is `false` (safe default — private IPs always blocked regardless of `AllowedHosts`)
- Full godoc and README documentation with security warning

## Test Plan

- [ ] `go test ./...` passes
- [ ] `go vet ./...` passes
- [ ] New tests cover port handling in `isURLSafe`
- [ ] New tests cover `AllowPrivateIPsForAllowedHosts` (blocked when false, allowed when true, blocked when host not in list)