### PR TITLE
[apache] Update MesiAllowedHosts config after port-agnostic fix

### DIFF
--- a/servers/apache/httpd.conf
+++ b/servers/apache/httpd.conf
@@ -3,7 +3,7 @@ LoadModule mesi_module /usr/lib/apache2/modules/mod_mesi.so
 LogLevel debug
 
 EnableMesi on
-MesiAllowedHosts backend:8000 raw.githubusercontent.com
+MesiAllowedHosts backend raw.githubusercontent.com
 MesiBlockPrivateIPs Off
 
 <VirtualHost *:80>


### PR DESCRIPTION
## Summary

After the port-agnostic fix in `isURLSafe` (using `Hostname()` instead of `Host`), the Apache test config `MesiAllowedHosts backend:8000` no longer works — `Hostname()` returns `backend` which doesn't match `backend:8000`.

Fix: change `MesiAllowedHosts backend:8000` to `MesiAllowedHosts backend` (port-agnostic matching handles the rest).

## Test Plan

- [ ] Apache Integration Test passes in CI
- [ ] `go test ./...` passes