### PR TITLE
fix(mesi): unescape strips one character too many after <!--esi literal (#109)

### DIFF
--- a/mesi/parser_test.go
+++ b/mesi/parser_test.go
@@ -37,7 +37,7 @@ func TestParse(t *testing.T) {
 			input:      "<!--esi <esi:include src=\"x\"/>-->",
 			maxDepth:   0,
 			defaultUrl: "http://example.com/",
-			expected:   "esi max depth",
+			expected:   " esi max depth",
 		},
 	}
 
@@ -405,7 +405,7 @@ func TestMESIParseSimpleStaticContent(t *testing.T) {
 		{"empty string", "", ""},
 		{"plain text", "Hello World", "Hello World"},
 		{"html without esi", "<html><body>Test</body></html>", "<html><body>Test</body></html>"},
-		{"esi comment without tags", "<!--esi plain text-->", "plain text"},
+		{"esi comment without tags", "<!--esi plain text-->", " plain text"},
 	}
 
 	for _, tt := range tests {
@@ -435,8 +435,8 @@ func TestMESIParseWithInclude(t *testing.T) {
 	input := `<!--esi <esi:include src="` + server.URL + `/test"/>-->`
 	result := MESIParse(input, config)
 
-	if result != "included content" {
-		t.Errorf("MESIParse() = %q, want %q", result, "included content")
+	if result != " included content" {
+		t.Errorf("MESIParse() = %q, want %q", result, " included content")
 	}
 }
 
@@ -583,7 +583,7 @@ func TestMESIParseNestedIncludes(t *testing.T) {
 	if callCount.Load() != 2 {
 		t.Errorf("Expected 2 HTTP calls for nested includes, got %d", callCount.Load())
 	}
-	if result != "inner content" {
-		t.Errorf("MESIParse() = %q, want %q", result, "inner content")
+	if result != "  inner content" {
+		t.Errorf("MESIParse() = %q, want %q", result, "  inner content")
 	}
 }

--- a/mesi/unescape.go
+++ b/mesi/unescape.go
@@ -3,10 +3,13 @@ package mesi
 import "strings"
 
 func unescape(input string) string {
+	const open = "<!--esi"
+	const close = "-->"
+
 	var result strings.Builder
 	pos := 0
 	for {
-		start := strings.Index(input[pos:], "<!--esi")
+		start := strings.Index(input[pos:], open)
 		if start == -1 {
 			result.WriteString(input[pos:])
 			return result.String()
@@ -17,14 +20,14 @@ func unescape(input string) string {
 			result.WriteString(input[pos:start])
 		}
 
-		end := strings.Index(input[start:], "-->")
+		bodyStart := start + len(open)
+		end := strings.Index(input[bodyStart:], close)
 		if end == -1 {
+			// unclosed — preserve original literal in output
 			result.WriteString(input[start:])
 			return result.String()
 		}
-		end += start + 3
-
-		result.WriteString(input[start+8 : end-3])
-		pos = end
+		result.WriteString(input[bodyStart : bodyStart+end])
+		pos = bodyStart + end + len(close)
 	}
 }

--- a/mesi/unescape_test.go
+++ b/mesi/unescape_test.go
@@ -8,14 +8,23 @@ func TestUnescape(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"normal closed tag", "Hello <!--esi <p>content</p>--> World", "Hello <p>content</p> World"},
+		// Original cases (with corrected expectation for the space-stripping bug)
+		{"normal closed tag", "Hello <!--esi <p>content</p>--> World", "Hello  <p>content</p> World"},
 		{"unclosed in middle", "Hello <!--esi <p>content", "Hello <!--esi <p>content"},
 		{"unclosed at start", "<!--esi <p>content", "<!--esi <p>content"},
 		{"empty input", "", ""},
 		{"no esi tags", "Plain text without ESI", "Plain text without ESI"},
-		{"multiple esi tags all closed", "A<!--esi X-->B<!--esi Y-->C", "AXBYC"},
-		{"closed then unclosed", "A<!--esi X-->B<!--esi Y", "AXB<!--esi Y"},
-		{"closed at end then unclosed", "<!--esi X-->Y<!--esi Z", "XY<!--esi Z"},
+		{"multiple esi tags all closed", "A<!--esi X-->B<!--esi Y-->C", "A XB YC"},
+		{"closed then unclosed", "A<!--esi X-->B<!--esi Y", "A XB<!--esi Y"},
+		{"closed at end then unclosed", "<!--esi X-->Y<!--esi Z", " XY<!--esi Z"},
+		// Bug #109: no space after open, newline, tab, multiple spaces
+		{"no space after open", "<!--esi<esi:include src=\"x\"/>-->", "<esi:include src=\"x\"/>"},
+		{"newline after open", "<!--esi\n<esi:include src=\"x\"/>\n-->", "\n<esi:include src=\"x\"/>\n"},
+		{"tab after open", "<!--esi\t<esi:include src=\"x\"/>-->", "\t<esi:include src=\"x\"/>"},
+		{"two spaces after open", "<!--esi  <esi:include src=\"x\"/>-->", "  <esi:include src=\"x\"/>"},
+		{"empty esi block", "<!--esi-->", ""},
+		{"empty esi block with trailing text", "<!--esi-->after", "after"},
+		{"multiple mixed spacing", "<!--esi<a/>--><!--esi <b/>-->", "<a/> <b/>"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes off-by-one in `unescape()` where hardcoded `+8` offset assumed a mandatory space after `<!--esi` literal (7 chars)
- Replaces magic offsets with named constants and `len()`
- Uses `bodyStart` (not `start`) as the anchor for `-->` search, avoiding off-by-one in edge cases

## Bug Impact

Any `<!--esi` block without a space immediately after the opening literal loses its first character:
- `<!--esi<esi:include src="x"/>-->` → `esi:include src="x"/>` (missing `<`)
- `<!--esi-->` → slice bounds panic
- Extra whitespace after `<!--esi  ` → only one space stripped

This is **not** a security issue, but can cause silent loss of entire include blocks.

## Test Plan

- [x] `go test ./mesi/ -count=1` — all pass
- [x] `go test ./... -count=1` — all pass
- [x] Existing test expectations updated to match correct ESI spec (whitespace after `<!--esi` is content, not a delimiter separator)
- [x] Added 7 new test cases: no space, newline, tab, two spaces, empty block, empty block with trailing text, mixed spacing

Closes #109