### PR TITLE
[apache] Fix Content-Type and status checks - multiple bugs (#93)

### DIFF
--- a/servers/apache/mod_mesi.c
+++ b/servers/apache/mod_mesi.c
@@ -161,13 +161,26 @@ static char *build_base_url(request_rec *r, apr_pool_t *pool) {
     return apr_psprintf(pool, "%s://%s/", scheme, host);
 }
 
+static int is_html_content(const char *ct) {
+    if (!ct) return 0;
+    // Skip leading whitespace (OWS per RFC 7230 §3.2.6)
+    while (*ct == ' ' || *ct == '\t') ct++;
+    // Case-insensitive media-type comparison (RFC 9110 §8.3.1)
+    if (strncasecmp(ct, "text/html", 9) != 0) return 0;
+    char delim = ct[9];
+    // Must be followed by delimiter, parameter separator, or end-of-string
+    return delim == '\0' || delim == ';' || delim == ' ' || delim == '\t'
+           || delim == '\r' || delim == '\n';
+}
+
 static int mesi_response_filter(ap_filter_t *f, apr_bucket_brigade *bb) {
     mesi_config *conf = (mesi_config *) ap_get_module_config(f->r->server->module_config, &mesi_module);
     if (!conf->enable_mesi) {
         return ap_pass_brigade(f->next, bb);
     }
 
-    if (!f->r->content_type || strncmp(f->r->content_type, "text/html", 9) != 0 || f->r->status > 400) {
+    if (!is_html_content(f->r->content_type) || f->r->status >= 400) {
+        ap_remove_output_filter(f);
         return ap_pass_brigade(f->next, bb);
     }
 

--- a/servers/apache/test.sh
+++ b/servers/apache/test.sh
@@ -119,6 +119,42 @@ else
     exit 1
 fi
 
+echo "=== Test 11: JSON content (application/json) not processed ==="
+RESPONSE=$(curl -s http://localhost:8080/noesi.json)
+if echo "$RESPONSE" | grep -q "esi:include"; then
+    echo "PASS: JSON content not processed (raw esi:include preserved)"
+else
+    echo "FAIL: JSON content was processed"
+    echo "Response: $RESPONSE"
+    exit 1
+fi
+# Also verify Content-Type is correct
+CT=$(curl -sI http://localhost:8080/noesi.json | grep -i "Content-Type")
+if echo "$CT" | grep -qi "application/json"; then
+    echo "PASS: JSON Content-Type is application/json"
+else
+    echo "FAIL: JSON Content-Type is wrong: $CT"
+    exit 1
+fi
+
+echo "=== Test 12: CSS content (text/css) not processed ==="
+RESPONSE=$(curl -s http://localhost:8080/noesi.css)
+if echo "$RESPONSE" | grep -q "esi:include"; then
+    echo "PASS: CSS content not processed (raw esi:include preserved)"
+else
+    echo "FAIL: CSS content was processed"
+    echo "Response: $RESPONSE"
+    exit 1
+fi
+# Also verify Content-Type is correct
+CT=$(curl -sI http://localhost:8080/noesi.css | grep -i "Content-Type")
+if echo "$CT" | grep -qi "text/css"; then
+    echo "PASS: CSS Content-Type is text/css"
+else
+    echo "FAIL: CSS Content-Type is wrong: $CT"
+    exit 1
+fi
+
 docker compose down
 
 echo ""

--- a/servers/apache/tests/noesi.css
+++ b/servers/apache/tests/noesi.css
@@ -1,0 +1,2 @@
+/* CSS file with ESI include */
+body { background: url(<esi:include src="http://backend:8000/ssrf-allowed.html"/>); }

--- a/servers/apache/tests/noesi.json
+++ b/servers/apache/tests/noesi.json
@@ -1,0 +1,1 @@
+{"message": "hello", "include": "<esi:include src=\"http://backend:8000/ssrf-allowed.html\"/>"}


### PR DESCRIPTION
Fixes #93

## Bugs fixed

| # | Bug | Fix |
|---|-----|-----|
| 1 | strncmp case-sensitive - TEXT/HTML rejected | strncasecmp (RFC 9110 8.3.1) |
| 2 | No delimiter check - text/htmlsafe processed | Validates char after 'text/html' (end-of-string/;/whitespace) |
| 3 | status > 400 - 400 Bad Request passes through | status >= 400 |
| 4 | No OWS skip - '  text/html' rejected | Skip leading whitespace per RFC 7230 |

Also: added ap_remove_output_filter on the decline path for perf.

## Tests added
- Test 11: JSON (application/json) with ESI tags -> NOT processed
- Test 12: CSS (text/css) with ESI tags -> NOT processed

## Verification
All 12 tests pass (existing 10 + 2 new).