### PR TITLE
fix(apache): uninitialized variable in mesi_response_filter (#134)

### DIFF
--- a/servers/apache/mod_mesi.c
+++ b/servers/apache/mod_mesi.c
@@ -211,7 +211,7 @@ static int mesi_response_filter(ap_filter_t *f, apr_bucket_brigade *bb) {
 
     // Flatten the accumulated body into a single NUL-terminated string.
     // If flattening fails, pass through raw data without ESI processing.
-    apr_size_t len;
+    apr_size_t len = 0;
     char *html = NULL;
     int flatten_ok = 0;
 


### PR DESCRIPTION
## Problem

In `mesi_response_filter`, `apr_size_t len` is declared without initialization:

```c
apr_size_t len;
```

When `apr_brigade_length` fails, `len` has indeterminate value (C11 §6.7.9p10). The current code path happens to be safe (short-circuit `&&` with NULL `html`), but this is a fragile invariant — any future change that reads `len` in the fallback path would introduce UB.

## Fix

```c
apr_size_t len = 0;
```

Zero-initialization makes the contract explicit and eliminates the entire class of bugs.

## Related

Closes #134
