### PR TITLE
fix(mesi): stop leaking internal error details into rendered HTML (#107)

### DIFF
--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -9,13 +9,17 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
 )
 
 var (
+	ErrInvalidURL         = errors.New("invalid url")
+	ErrSSRFBlocked        = errors.New("ssrf blocked")
+	ErrUpstreamStatus     = errors.New("upstream bad status")
+	ErrTimeBudgetExceeded = errors.New("exceeded time budget")
+
 	_, cgnatCIDR, _         = net.ParseCIDR("100.64.0.0/10")
 	_, benchmarkCIDR, _     = net.ParseCIDR("198.18.0.0/15")
 	_, reserved240CIDR, _   = net.ParseCIDR("240.0.0.0/4")
@@ -41,7 +45,7 @@ type httpDoer interface {
 func isURLSafe(requestedURL string, config EsiParserConfig) error {
 	parsedURL, err := url.Parse(requestedURL)
 	if err != nil {
-		return errors.New("invalid url: " + err.Error())
+		return fmt.Errorf("%w: %s", ErrInvalidURL, err.Error())
 	}
 
 	host := parsedURL.Hostname()
@@ -53,7 +57,7 @@ func isURLSafe(requestedURL string, config EsiParserConfig) error {
 
 	// Absolute URLs must have a host
 	if host == "" {
-		return errors.New("url has no host")
+		return fmt.Errorf("%w: url has no host", ErrInvalidURL)
 	}
 
 	if len(config.AllowedHosts) > 0 {
@@ -65,7 +69,7 @@ func isURLSafe(requestedURL string, config EsiParserConfig) error {
 			}
 		}
 		if !allowed {
-			return errors.New("host not in allowed list: " + host)
+			return fmt.Errorf("%w: host not in allowed list: %s", ErrSSRFBlocked, host)
 		}
 	}
 
@@ -127,7 +131,7 @@ func safeDialer(config EsiParserConfig) *net.Dialer {
 				return fmt.Errorf("internal error: dial address expected to be IP but got: %s", host)
 			}
 			if config.BlockPrivateIPs && isPrivateOrReservedIP(ip) {
-				return fmt.Errorf("blocked dial to private/reserved ip: %s", ip)
+				return fmt.Errorf("%w: blocked dial to private/reserved ip", ErrSSRFBlocked)
 			}
 			return nil
 		},
@@ -172,21 +176,21 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 
 	if config.Timeout <= 0 {
 		logger.Debug("fetch_timeout", "url", requestedURL, "error", "exceeded time budget")
-		return "", false, errors.New("exceeded time budget")
+		return "", false, fmt.Errorf("%w", ErrTimeBudgetExceeded)
 	}
 
 	parsed, err := url.Parse(requestedURL)
 	if err != nil {
-		return "", false, errors.New("invalid url: " + err.Error())
+		return "", false, fmt.Errorf("%w: %s", ErrInvalidURL, err.Error())
 	}
 
 	if parsed.Scheme != "" && parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return "", false, errors.New("invalid url scheme: " + parsed.Scheme)
+		return "", false, fmt.Errorf("%w: invalid url scheme: %s", ErrInvalidURL, parsed.Scheme)
 	}
 
 	if err := isURLSafe(requestedURL, config); err != nil {
 		logger.Debug("fetch_ssrf_error", "url", requestedURL, "error", err.Error())
-		return "", false, errors.New("ssrf validation failed: " + err.Error())
+		return "", false, fmt.Errorf("%w: %s", ErrSSRFBlocked, err.Error())
 	}
 
 	var client httpDoer
@@ -210,7 +214,7 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 	var urlToFetch string
 	if parsed.Scheme == "" {
 		if config.DefaultUrl == "" {
-			return "", false, errors.New("default url can't be empty, on relative urls: " + requestedURL)
+			return "", false, fmt.Errorf("%w: default url can't be empty, on relative urls: %s", ErrInvalidURL, requestedURL)
 		}
 		urlToFetch = strings.TrimRight(config.DefaultUrl, "/") + "/" + strings.TrimLeft(requestedURL, "/")
 	} else {
@@ -233,7 +237,7 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 
 	req, err := http.NewRequestWithContext(ctx, "GET", urlToFetch, nil)
 	if err != nil {
-		return "", false, errors.New("failed to create request: " + err.Error())
+		return "", false, fmt.Errorf("%w: %s", ErrInvalidURL, err.Error())
 	}
 	req.Header.Set("Surrogate-Capability", "ESI/1.0")
 
@@ -242,7 +246,7 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 	content, err := client.Do(req)
 	if err != nil {
 		logger.Debug("fetch_error", "url", urlToFetch, "error", err.Error())
-		return "", false, err
+		return "", false, errors.Join(ErrUpstreamStatus, err)
 	}
 	logger.Debug("fetch_done", "url", urlToFetch, "duration", time.Since(reqStart), "status", content.StatusCode)
 	defer func() { _ = content.Body.Close() }()
@@ -253,7 +257,7 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 		limitedReader := io.LimitReader(content.Body, config.MaxResponseSize+1)
 		dataBytes, err = io.ReadAll(limitedReader)
 		if err != nil {
-			return "", false, err
+			return "", false, errors.Join(ErrUpstreamStatus, err)
 		}
 		if int64(len(dataBytes)) > config.MaxResponseSize {
 			return "", false, fmt.Errorf("response body exceeds maximum allowed size of %d bytes", config.MaxResponseSize)
@@ -262,12 +266,12 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 		// No limit - backward compatibility
 		dataBytes, err = io.ReadAll(content.Body)
 		if err != nil {
-			return "", false, err
+			return "", false, errors.Join(ErrUpstreamStatus, err)
 		}
 	}
 
 	if content.StatusCode >= 400 {
-		return "", false, errors.New("upstream returned status " + strconv.Itoa(content.StatusCode))
+		return "", false, fmt.Errorf("%w: upstream returned status %d", ErrUpstreamStatus, content.StatusCode)
 	}
 	contentStr := string(dataBytes)
 	if config.Cache != nil && cacheKey != "" {

--- a/mesi/fetchUrl_test.go
+++ b/mesi/fetchUrl_test.go
@@ -2,6 +2,7 @@ package mesi
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -551,8 +552,8 @@ func TestFetchConcurrentBothFail(t *testing.T) {
 	html := `<html><esi:include src="` + server.URL + `/fail1" alt="` + server.URL + `/fail2" fetch-mode="concurrent" /></html>`
 
 	result := MESIParse(html, config)
-	if !strings.Contains(result, "500") && !strings.Contains(result, "error") {
-		t.Errorf("expected error in output when both URLs fail, got %q", result)
+	if strings.Contains(result, "500") || strings.Contains(result, "error") {
+		t.Errorf("error details leaked into output: %q", result)
 	}
 }
 
@@ -846,23 +847,37 @@ func TestSingleFetchUrlSSRFValidation(t *testing.T) {
 }
 
 func TestParseWithConfigAllowedHostsAndBlockPrivateIPs(t *testing.T) {
-	if out := MESIParse(`<esi:include src="http://evil.com/test" />`, EsiParserConfig{
+	log := &recordingLogger{}
+
+	out := MESIParse(`<esi:include src="http://evil.com/test" />`, EsiParserConfig{
 		DefaultUrl:      "http://example.com/",
 		MaxDepth:        5,
 		Timeout:         30 * time.Second,
 		AllowedHosts:    []string{"allowed.com"},
 		BlockPrivateIPs: true,
-	}); !strings.Contains(out, "host not in allowed list") {
-		t.Fatalf("expected allowed-host SSRF block, got %q", out)
+		Logger:          log,
+	})
+	if out != "" {
+		t.Fatalf("expected empty output for blocked include, got %q", out)
+	}
+	if !log.containsMsg("include_failed") {
+		t.Fatal("expected include_failed log for allowed-host block")
 	}
 
-	if out := MESIParse(`<esi:include src="http://127.0.0.1/test" />`, EsiParserConfig{
+	log.entries = nil
+
+	out = MESIParse(`<esi:include src="http://127.0.0.1/test" />`, EsiParserConfig{
 		DefaultUrl:      "http://example.com/",
 		MaxDepth:        5,
 		Timeout:         30 * time.Second,
 		BlockPrivateIPs: true,
-	}); !strings.Contains(out, "blocked") {
-		t.Fatalf("expected private IP SSRF block, got %q", out)
+		Logger:          log,
+	})
+	if out != "" {
+		t.Fatalf("expected empty output for blocked include, got %q", out)
+	}
+	if !log.containsMsg("include_failed") {
+		t.Fatal("expected include_failed log for private IP block")
 	}
 }
 
@@ -1263,52 +1278,120 @@ func TestNewSSRFSafeTransport(t *testing.T) {
 }
 
 func TestSSRFBlocksIPv6Loopback(t *testing.T) {
+	log := &recordingLogger{}
 	config := EsiParserConfig{
 		DefaultUrl:      "http://example.com/",
 		MaxDepth:        1,
 		Timeout:         1 * time.Second,
 		BlockPrivateIPs: true,
-		Logger:          DiscardLogger{},
+		Logger:          log,
 	}
 
 	html := `<html><body><esi:include src="http://[::1]/test"/></body></html>`
 	result := MESIParse(html, config)
 
-	if !strings.Contains(result, "blocked dial to private/reserved ip") {
-		t.Errorf("expected SSRF block for IPv6 loopback, got: %q", result)
+	if strings.Contains(result, "::1") {
+		t.Errorf("output leaked internal IP: %q", result)
+	}
+	if !log.containsMsg("include_failed") {
+		t.Errorf("expected include_failed log for IPv6 loopback block, got: %q", result)
 	}
 }
 
 func TestSSRFBlocksIPv6ULA(t *testing.T) {
+	log := &recordingLogger{}
 	config := EsiParserConfig{
 		DefaultUrl:      "http://example.com/",
 		MaxDepth:        1,
 		Timeout:         1 * time.Second,
 		BlockPrivateIPs: true,
-		Logger:          DiscardLogger{},
+		Logger:          log,
 	}
 
 	html := `<html><body><esi:include src="http://[fd00::1]/test"/></body></html>`
 	result := MESIParse(html, config)
 
-	if !strings.Contains(result, "blocked dial to private/reserved ip") {
-		t.Errorf("expected SSRF block for IPv6 ULA, got: %q", result)
+	if strings.Contains(result, "fd00") {
+		t.Errorf("output leaked internal IP: %q", result)
+	}
+	if !log.containsMsg("include_failed") {
+		t.Errorf("expected include_failed log for IPv6 ULA block, got: %q", result)
 	}
 }
 
 func TestSSRFBlocksIPv4MappedIPv6(t *testing.T) {
+	log := &recordingLogger{}
 	config := EsiParserConfig{
 		DefaultUrl:      "http://example.com/",
 		MaxDepth:        1,
 		Timeout:         1 * time.Second,
 		BlockPrivateIPs: true,
-		Logger:          DiscardLogger{},
+		Logger:          log,
 	}
 
 	html := `<html><body><esi:include src="http://[::ffff:127.0.0.1]/test"/></body></html>`
 	result := MESIParse(html, config)
 
-	if !strings.Contains(result, "blocked dial to private/reserved ip") {
-		t.Errorf("expected SSRF block for IPv4-mapped IPv6, got: %q", result)
+	if strings.Contains(result, "127.0.0.1") {
+		t.Errorf("output leaked internal IP: %q", result)
+	}
+	if !log.containsMsg("include_failed") {
+		t.Errorf("expected include_failed log for IPv4-mapped IPv6 block, got: %q", result)
+	}
+}
+
+func TestSentinelErrorsIs(t *testing.T) {
+	_, _, schemeErr := singleFetchUrlWithContext("httpx://example.com/test", EsiParserConfig{Timeout: time.Second, BlockPrivateIPs: false, Logger: DiscardLogger{}}, context.Background())
+	_, _, timeoutErr := singleFetchUrlWithContext("http://example.com/test", EsiParserConfig{Timeout: 0, BlockPrivateIPs: false, Logger: DiscardLogger{}}, context.Background())
+	_, _, dialErr := singleFetchUrlWithContext("http://127.0.0.1/test", EsiParserConfig{Timeout: time.Second, BlockPrivateIPs: true, Logger: DiscardLogger{}}, context.Background())
+	hostErr := isURLSafe("http://evil.com/test", EsiParserConfig{AllowedHosts: []string{"allowed.com"}})
+
+	tests := []struct {
+		name   string
+		err    error
+		target error
+		want   bool
+	}{
+		{
+			name:   "invalid scheme wraps ErrInvalidURL",
+			err:    schemeErr,
+			target: ErrInvalidURL,
+			want:   true,
+		},
+		{
+			name:   "timeout wraps ErrTimeBudgetExceeded",
+			err:    timeoutErr,
+			target: ErrTimeBudgetExceeded,
+			want:   true,
+		},
+		{
+			name:   "dial SSRF block wraps ErrSSRFBlocked",
+			err:    dialErr,
+			target: ErrSSRFBlocked,
+			want:   true,
+		},
+		{
+			name:   "allowed-host SSRF block wraps ErrSSRFBlocked",
+			err:    hostErr,
+			target: ErrSSRFBlocked,
+			want:   true,
+		},
+		{
+			name:   "host-not-allowed not ErrInvalidURL",
+			err:    hostErr,
+			target: ErrInvalidURL,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.err == nil {
+				t.Fatal("expected non-nil error")
+			}
+			if got := errors.Is(tt.err, tt.target); got != tt.want {
+				t.Errorf("errors.Is(%v, %v) = %v, want %v\nerr.Error() = %q", tt.err, tt.target, got, tt.want, tt.err)
+			}
+		})
 	}
 }

--- a/mesi/include.go
+++ b/mesi/include.go
@@ -193,6 +193,8 @@ func (token *esiIncludeToken) toString(config EsiParserConfig) (string, bool) {
 	}
 
 	if err != nil {
+		logger.Debug("include_failed", "src", token.Src, "error", err.Error())
+
 		if token.OnError == "continue" {
 			return "", false
 		}
@@ -201,7 +203,7 @@ func (token *esiIncludeToken) toString(config EsiParserConfig) (string, bool) {
 			return token.Content, false
 		}
 
-		return err.Error(), false
+		return config.IncludeErrorMarker, false
 	}
 
 	return data, isEsiResponse

--- a/mesi/include_test.go
+++ b/mesi/include_test.go
@@ -3,8 +3,31 @@ package mesi
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
+
+type logEntry struct {
+	msg     string
+	keyvals []interface{}
+}
+
+type recordingLogger struct {
+	entries []logEntry
+}
+
+func (l *recordingLogger) Debug(msg string, keyvals ...interface{}) {
+	l.entries = append(l.entries, logEntry{msg: msg, keyvals: keyvals})
+}
+
+func (l *recordingLogger) containsMsg(substr string) bool {
+	for _, e := range l.entries {
+		if strings.Contains(e.msg, substr) {
+			return true
+		}
+	}
+	return false
+}
 
 func TestParseIncludeAttributes(t *testing.T) {
 	cases := []struct {
@@ -251,6 +274,61 @@ func TestFetchConcurrentHappyPath(t *testing.T) {
 	}
 }
 
+func TestToStringErrorDoesNotLeakInternalDetails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("SECRET_INTERNAL_DATA"))
+	}))
+	defer server.Close()
+
+	token := &esiIncludeToken{
+		Src: server.URL + "/fail",
+	}
+
+	log := &recordingLogger{}
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+	config.Logger = log
+
+	data, _ := token.toString(config)
+	if data != "" {
+		t.Errorf("toString() = %q, want empty string (no error leak)", data)
+	}
+	if strings.Contains(data, "SECRET_INTERNAL_DATA") {
+		t.Error("toString() leaked response body")
+	}
+	if strings.Contains(data, "500") {
+		t.Error("toString() leaked status code")
+	}
+	if !log.containsMsg("include_failed") {
+		t.Error("expected include_failed log entry")
+	}
+}
+
+func TestIncludeErrorMarkerCustom(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	token := &esiIncludeToken{
+		Src: server.URL + "/fail",
+	}
+
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+	config.IncludeErrorMarker = "<!-- esi error -->"
+
+	data, _ := token.toString(config)
+	if data != "<!-- esi error -->" {
+		t.Errorf("toString() = %q, want %q", data, "<!-- esi error -->")
+	}
+}
+
 func TestToStringWithOnerrorContinue(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -305,13 +383,18 @@ func TestToStringWithMaxDepthExceeded(t *testing.T) {
 		Src: server.URL + "/fragment",
 	}
 
+	log := &recordingLogger{}
 	config := CreateDefaultConfig()
 	config.DefaultUrl = server.URL + "/"
 	config.MaxDepth = 0
 	config.BlockPrivateIPs = false
+	config.Logger = log
 
 	data, _ := token.toString(config)
-	if data != "esi max depth" {
-		t.Errorf("toString() = %q, want %q", data, "esi max depth")
+	if data != "" {
+		t.Errorf("toString() = %q, want empty string (no error leak)", data)
+	}
+	if !log.containsMsg("include_failed") {
+		t.Error("expected include_failed log entry")
 	}
 }

--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -43,6 +43,11 @@ type EsiParserConfig struct {
 	CacheKeyFunc                   CacheKeyFunc  // Custom cache key function (nil = DefaultCacheKey)
 	Debug                          bool          // Enable debug logging
 	Logger                         Logger        // Custom logger (nil = DiscardLogger when Debug is false)
+	// IncludeErrorMarker is rendered in place of a failed include when no
+	// onerror="continue" and no fallback <esi:include> body is present.
+	// Default: "" (silent). Set to something like "<!-- esi error -->" for
+	// debugging, but NEVER include the raw error — see security advisory.
+	IncludeErrorMarker             string
 	requestSemaphore               chan struct{} // semaphore for limiting HTTP requests
 }
 

--- a/mesi/parser_test.go
+++ b/mesi/parser_test.go
@@ -33,11 +33,15 @@ func TestParse(t *testing.T) {
 			expected:   "<html><body>Hello World</body></html>",
 		},
 		{
-			name:       "max depth 0 with include triggers max depth error",
+			// The leading space comes from unescape stripping the "<!--esi" and "-->" markers,
+			// leaving " <esi:include src=\"x\"/>". The space before the tag is preserved as a
+			// static token. The include produces empty output (IncludeErrorMarker default),
+			// so only the space remains.
+			name:       "max depth 0 with include produces empty (error not leaked)",
 			input:      "<!--esi <esi:include src=\"x\"/>-->",
 			maxDepth:   0,
 			defaultUrl: "http://example.com/",
-			expected:   " esi max depth",
+			expected:   " ",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Security fix: `esiIncludeToken.toString` returned raw `err.Error()` as ESI-substituted content when an include failed without `onerror="continue"` or fallback body. Error strings include internal topology (private IPs, hostnames, upstream status codes), aiding SSRF reconnaissance.

## Changes

- **`EsiParserConfig.IncludeErrorMarker`** — new field (default: `""` silent). Rendered in place of a failed include. Set to e.g. `"<!-- esi error -->"` for debugging.
- **`toString`** — now logs error via configured `Logger` with `"include_failed"` event, returns `config.IncludeErrorMarker` instead of `err.Error()`.
- **Sentinel errors** — `ErrInvalidURL`, `ErrSSRFBlocked`, `ErrUpstreamStatus`, `ErrTimeBudgetExceeded` with `%w` wrapping.
- **Tests** — `recordingLogger` helper, `TestToStringErrorDoesNotLeakInternalDetails`, `TestIncludeErrorMarkerCustom`. Updated all tests that previously asserted error text in output.