### PR TITLE
fix(mesi): route cache errors through configured Logger instead of log.Printf (#110)

### DIFF
--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -229,7 +228,7 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 		}
 		cacheKey = cacheKeyFunc(urlToFetch)
 		if val, ok, err := config.Cache.Get(ctx, cacheKey); err != nil {
-			log.Printf("mesi: cache get error for key %q: %v", cacheKey, err)
+			logger.Warn("cache_get_error", "key", cacheKey, "error", err.Error())
 		} else if ok {
 			return val, false, nil
 		}
@@ -276,7 +275,7 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 	contentStr := string(dataBytes)
 	if config.Cache != nil && cacheKey != "" {
 		if err := config.Cache.Set(ctx, cacheKey, contentStr, config.CacheTTL); err != nil {
-			log.Printf("mesi: cache set error for key %q: %v", cacheKey, err)
+			logger.Warn("cache_set_error", "key", cacheKey, "error", err.Error())
 		}
 	}
 	return contentStr, IsEsiResponse(content), nil

--- a/mesi/fetchUrl.go
+++ b/mesi/fetchUrl.go
@@ -228,7 +228,7 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 		}
 		cacheKey = cacheKeyFunc(urlToFetch)
 		if val, ok, err := config.Cache.Get(ctx, cacheKey); err != nil {
-			logger.Warn("cache_get_error", "key", cacheKey, "error", err.Error())
+			config.warn("cache_get_error", "key", cacheKey, "error", err.Error())
 		} else if ok {
 			return val, false, nil
 		}
@@ -275,7 +275,7 @@ func singleFetchUrlWithContext(requestedURL string, config EsiParserConfig, ctx 
 	contentStr := string(dataBytes)
 	if config.Cache != nil && cacheKey != "" {
 		if err := config.Cache.Set(ctx, cacheKey, contentStr, config.CacheTTL); err != nil {
-			logger.Warn("cache_set_error", "key", cacheKey, "error", err.Error())
+			config.warn("cache_set_error", "key", cacheKey, "error", err.Error())
 		}
 	}
 	return contentStr, IsEsiResponse(content), nil

--- a/mesi/fetchUrl_test.go
+++ b/mesi/fetchUrl_test.go
@@ -1398,6 +1398,8 @@ func TestSentinelErrorsIs(t *testing.T) {
 	}
 }
 
+var _ Cache = errorCache{}
+
 type errorCache struct{}
 
 func (errorCache) Get(_ context.Context, key string) (string, bool, error) {
@@ -1427,6 +1429,7 @@ func TestCacheGetErrorGoesToLogger(t *testing.T) {
 		BlockPrivateIPs: false,
 		Logger:          logger,
 		Cache:           errorCache{},
+		CacheKeyFunc:    DefaultCacheKey,
 	}
 
 	content, _, err := singleFetchUrlWithContext(server.URL+"/test", config, context.Background())

--- a/mesi/fetchUrl_test.go
+++ b/mesi/fetchUrl_test.go
@@ -1,8 +1,10 @@
 package mesi
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -1393,5 +1395,110 @@ func TestSentinelErrorsIs(t *testing.T) {
 				t.Errorf("errors.Is(%v, %v) = %v, want %v\nerr.Error() = %q", tt.err, tt.target, got, tt.want, tt.err)
 			}
 		})
+	}
+}
+
+type errorCache struct{}
+
+func (errorCache) Get(_ context.Context, key string) (string, bool, error) {
+	return "", false, errors.New("cache get failed: " + key)
+}
+
+func (errorCache) Set(_ context.Context, key, value string, _ time.Duration) error {
+	return errors.New("cache set failed: " + key)
+}
+
+func (errorCache) Delete(_ context.Context, key string) error {
+	return nil
+}
+
+func TestCacheGetErrorGoesToLogger(t *testing.T) {
+	logger := &recordingLogger{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("origin content"))
+	}))
+	defer server.Close()
+
+	config := EsiParserConfig{
+		DefaultUrl:      server.URL + "/",
+		MaxDepth:        1,
+		Timeout:         5 * time.Second,
+		BlockPrivateIPs: false,
+		Logger:          logger,
+		Cache:           errorCache{},
+	}
+
+	content, _, err := singleFetchUrlWithContext(server.URL+"/test", config, context.Background())
+	if err != nil {
+		t.Fatalf("expected fallback to origin on cache get error, got: %v", err)
+	}
+	if content != "origin content" {
+		t.Fatalf("expected 'origin content', got %q", content)
+	}
+	if !logger.containsMsg("cache_get_error") {
+		t.Fatal("expected cache_get_error log entry")
+	}
+}
+
+func TestCacheSetErrorGoesToLogger(t *testing.T) {
+	logger := &recordingLogger{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("origin content"))
+	}))
+	defer server.Close()
+
+	config := EsiParserConfig{
+		DefaultUrl:      server.URL + "/",
+		MaxDepth:        1,
+		Timeout:         5 * time.Second,
+		BlockPrivateIPs: false,
+		Logger:          logger,
+		Cache:           errorCache{},
+		CacheKeyFunc:    DefaultCacheKey,
+	}
+
+	content, _, err := singleFetchUrlWithContext(server.URL+"/test", config, context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content != "origin content" {
+		t.Fatalf("expected 'origin content', got %q", content)
+	}
+	if !logger.containsMsg("cache_set_error") {
+		t.Fatal("expected cache_set_error log entry")
+	}
+}
+
+func TestCacheErrorDoesNotReachStderr(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(nil)
+
+	logger := &recordingLogger{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("origin content"))
+	}))
+	defer server.Close()
+
+	config := EsiParserConfig{
+		DefaultUrl:      server.URL + "/",
+		MaxDepth:        1,
+		Timeout:         5 * time.Second,
+		BlockPrivateIPs: false,
+		Logger:          logger,
+		Cache:           errorCache{},
+		CacheKeyFunc:    DefaultCacheKey,
+	}
+
+	_, _, err := singleFetchUrlWithContext(server.URL+"/test", config, context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if buf.Len() > 0 {
+		t.Fatalf("stdlib log received unexpected output: %s", buf.String())
 	}
 }

--- a/mesi/include_test.go
+++ b/mesi/include_test.go
@@ -20,6 +20,10 @@ func (l *recordingLogger) Debug(msg string, keyvals ...interface{}) {
 	l.entries = append(l.entries, logEntry{msg: msg, keyvals: keyvals})
 }
 
+func (l *recordingLogger) Warn(msg string, keyvals ...interface{}) {
+	l.entries = append(l.entries, logEntry{msg: msg, keyvals: keyvals})
+}
+
 func (l *recordingLogger) containsMsg(substr string) bool {
 	for _, e := range l.entries {
 		if strings.Contains(e.msg, substr) {

--- a/mesi/include_test.go
+++ b/mesi/include_test.go
@@ -12,6 +12,8 @@ type logEntry struct {
 	keyvals []interface{}
 }
 
+var _ Logger = &recordingLogger{}
+
 type recordingLogger struct {
 	entries []logEntry
 }

--- a/mesi/logger.go
+++ b/mesi/logger.go
@@ -9,6 +9,10 @@ import (
 
 type Logger interface {
 	Debug(msg string, keyvals ...interface{})
+}
+
+type LoggerWarn interface {
+	Logger
 	Warn(msg string, keyvals ...interface{})
 }
 

--- a/mesi/logger.go
+++ b/mesi/logger.go
@@ -9,11 +9,13 @@ import (
 
 type Logger interface {
 	Debug(msg string, keyvals ...interface{})
+	Warn(msg string, keyvals ...interface{})
 }
 
 type DiscardLogger struct{}
 
 func (DiscardLogger) Debug(msg string, keyvals ...interface{}) {}
+func (DiscardLogger) Warn(msg string, keyvals ...interface{}) {}
 
 type DefaultLogger struct {
 	w io.Writer
@@ -24,15 +26,22 @@ func DefaultLoggerNew() DefaultLogger {
 }
 
 func (l DefaultLogger) Debug(msg string, keyvals ...interface{}) {
+	l.log("DEBUG", msg, keyvals...)
+}
+
+func (l DefaultLogger) Warn(msg string, keyvals ...interface{}) {
+	l.log("WARN", msg, keyvals...)
+}
+
+func (l DefaultLogger) log(level, msg string, keyvals ...interface{}) {
 	now := time.Now().Format(time.RFC3339)
-	fmt.Fprintf(l.w, "%s DEBUG %s", now, msg)
+	fmt.Fprintf(l.w, "%s %s %s", now, level, msg)
 	if len(keyvals) > 0 {
 		fmt.Fprint(l.w, " ")
 		for i := 0; i < len(keyvals); i += 2 {
 			if i+1 < len(keyvals) {
 				fmt.Fprintf(l.w, "%v=%v", keyvals[i], keyvals[i+1])
 			} else {
-				// Odd number of keyvals, log the last key with MISSING value
 				fmt.Fprintf(l.w, "%v=MISSING", keyvals[i])
 			}
 			if i+2 < len(keyvals) {

--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -72,6 +72,15 @@ func (c EsiParserConfig) getLogger() Logger {
 	return discardLogger
 }
 
+func (c EsiParserConfig) warn(msg string, keyvals ...interface{}) {
+	logger := c.getLogger()
+	if w, ok := logger.(LoggerWarn); ok {
+		w.Warn(msg, keyvals...)
+	} else {
+		logger.Debug(msg, keyvals...)
+	}
+}
+
 func (c EsiParserConfig) SetContext(ctx context.Context) EsiParserConfig {
 	c.Context = ctx
 	return c


### PR DESCRIPTION
Closes #110

## Summary

Cache read/write errors in fetchUrl.go were using log.Printf from the standard library, bypassing the Logger abstraction. Custom Logger implementations never saw cache errors, DiscardLogger still produced log spam, and library code wrote directly to global log.

## Changes

- **mesi/logger.go**: added Warn() to Logger interface + DiscardLogger (no-op) and DefaultLogger (WARN level)
- **mesi/fetchUrl.go**: replaced log.Printf with logger.Warn; removed log import
- **mesi/include_test.go**: added Warn() to recordingLogger
- **mesi/fetchUrl_test.go**: three new tests (cache_get_error, cache_set_error, no stderr leak)

## Acceptance criteria

- [x] No log.Printf calls remain in mesi/
- [x] Cache errors surface through config.Logger
- [x] recordingLogger updated with Warn support
- [x] New tests validate both error paths and confirm nothing leaks to stdlib log