### PR TITLE
fix(mesi): bound goroutine pool and inline static tokens in MESIParse (#115)

### DIFF
--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -3,9 +3,11 @@ package mesi
 import (
 	"context"
 	"net/http"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -48,6 +50,10 @@ type EsiParserConfig struct {
 	// Default: "" (silent). Set to something like "<!-- esi error -->" for
 	// debugging, but NEVER include the raw error — see security advisory.
 	IncludeErrorMarker             string
+	// MaxWorkers caps the number of goroutines used to process ESI tokens
+	// within a single MESIParse call. Zero means runtime.NumCPU()*4.
+	// Static tokens do not count against this limit.
+	MaxWorkers                     int
 	requestSemaphore               chan struct{} // semaphore for limiting HTTP requests
 }
 
@@ -195,8 +201,6 @@ func MESIParse(input string, config EsiParserConfig) string {
 
 	logger.Debug("parse_start", "input_size", len(input), "token_count", len(tokens))
 
-	ch := make(chan Response, len(tokens))
-
 	var semaphore chan struct{}
 	if config.MaxConcurrentRequests < 0 {
 		config.MaxConcurrentRequests = 0
@@ -206,46 +210,87 @@ func MESIParse(input string, config EsiParserConfig) string {
 		config = config.setSemaphore(semaphore)
 	}
 
+	type esiJob struct {
+		id    int
+		token esiToken
+	}
+	var esiJobs []esiJob
+	var results []Response
+
 	for index, token := range tokens {
-		go func(id int, token esiToken, ch chan<- Response, cfg EsiParserConfig, l Logger) {
-			res := Response{"", id}
-			if !token.isEsi() {
-				res.content = token.staticContent
-			} else if token.esiTagType == "include" {
-				l.Debug("token_processing", "token_type", token.esiTagType, "index", id)
-
-				include, err := parseInclude(token.esiTagContent)
-				if err != nil {
-					l.Debug("parse_error", "error", err.Error())
-					ch <- res
-					return
-				}
-				newConfig := cfg.OverrideConfig(include).WithElapsedTime(time.Since(start))
-				content, isEsiResponse := include.toString(newConfig)
-
-				if cfg.CanGoDeeper(time.Since(start)) && (isEsiResponse || !newConfig.ParseOnHeader) {
-					content = MESIParse(content, newConfig.DecreaseMaxDepth().WithElapsedTime(time.Since(start)))
-				}
-
-				res.content = content
-			} else {
-				l.Debug("token_processing", "token_type", token.esiTagType, "index", id)
-			}
-
-			ch <- res
-		}(index, token, ch, config, logger)
+		if !token.isEsi() {
+			results = append(results, Response{token.staticContent, index})
+		} else {
+			esiJobs = append(esiJobs, esiJob{index, token})
+		}
 	}
 
-	var results []Response
-ResultLoop:
-	for range tokens {
-		select {
-		case <-ctx.Done():
-			// Goroutines will send to buffered channel (capacity = len(tokens))
-			// and exit. Context cancellation stops in-flight HTTP requests.
-			break ResultLoop
-		case res := <-ch:
-			results = append(results, res)
+	if len(esiJobs) > 0 {
+		maxWorkers := config.MaxWorkers
+		if maxWorkers <= 0 {
+			maxWorkers = runtime.NumCPU() * 4
+		}
+
+		ch := make(chan Response, len(esiJobs))
+
+		workerCount := maxWorkers
+		if workerCount > len(esiJobs) {
+			workerCount = len(esiJobs)
+		}
+
+		var wg sync.WaitGroup
+		jobs := make(chan esiJob)
+
+		for range workerCount {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for job := range jobs {
+					id := job.id
+					token := job.token
+					res := Response{"", id}
+
+					if token.esiTagType == "include" {
+						logger.Debug("token_processing", "token_type", token.esiTagType, "index", id)
+
+						include, err := parseInclude(token.esiTagContent)
+						if err != nil {
+							logger.Debug("parse_error", "error", err.Error())
+							ch <- res
+							continue
+						}
+						newConfig := config.OverrideConfig(include).WithElapsedTime(time.Since(start))
+						content, isEsiResponse := include.toString(newConfig)
+
+						if config.CanGoDeeper(time.Since(start)) && (isEsiResponse || !newConfig.ParseOnHeader) {
+							content = MESIParse(content, newConfig.DecreaseMaxDepth().WithElapsedTime(time.Since(start)))
+						}
+
+						res.content = content
+					} else {
+						logger.Debug("token_processing", "token_type", token.esiTagType, "index", id)
+					}
+
+					ch <- res
+				}
+			}()
+		}
+
+		for _, job := range esiJobs {
+			jobs <- job
+		}
+		close(jobs)
+
+	ResultLoop:
+		for i := 0; i < len(esiJobs); i++ {
+			select {
+			case <-ctx.Done():
+				// Workers will send to buffered channel (capacity = len(esiJobs))
+				// and exit when jobs channel is fully consumed.
+				break ResultLoop
+			case res := <-ch:
+				results = append(results, res)
+			}
 		}
 	}
 

--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -239,7 +239,7 @@ func MESIParse(input string, config EsiParserConfig) string {
 		}
 
 		var wg sync.WaitGroup
-		jobs := make(chan esiJob)
+		jobs := make(chan esiJob, len(esiJobs))
 
 		for range workerCount {
 			wg.Add(1)
@@ -285,13 +285,13 @@ func MESIParse(input string, config EsiParserConfig) string {
 		for i := 0; i < len(esiJobs); i++ {
 			select {
 			case <-ctx.Done():
-				// Workers will send to buffered channel (capacity = len(esiJobs))
-				// and exit when jobs channel is fully consumed.
 				break ResultLoop
 			case res := <-ch:
 				results = append(results, res)
 			}
 		}
+
+		wg.Wait()
 	}
 
 	return assembleResults(results, result)

--- a/mesi/parser_test.go
+++ b/mesi/parser_test.go
@@ -400,6 +400,47 @@ func TestOverrideConfigWithMaxDepth(t *testing.T) {
 	}
 }
 
+func TestMESIParseWorkerPoolRespectsMaxWorkers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping concurrency test in short mode")
+	}
+
+	var maxConcurrent atomic.Int64
+	var current atomic.Int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v := current.Add(1)
+		if p := maxConcurrent.Load(); v > p {
+			maxConcurrent.CompareAndSwap(p, v)
+		}
+		time.Sleep(50 * time.Millisecond)
+		current.Add(-1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("content"))
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.MaxWorkers = 2
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+	// Disable HTTP-level semaphore to test worker pool independently
+	config.MaxConcurrentRequests = 0
+
+	var input string
+	for i := 0; i < 10; i++ {
+		input += `<!--esi <esi:include src="` + server.URL + `/` + strconv.Itoa(i) + `"/>-->`
+	}
+
+	MESIParse(input, config)
+
+	mc := maxConcurrent.Load()
+	if mc > 2 {
+		t.Errorf("max concurrent includes = %d, want <= 2 (MaxWorkers=2)", mc)
+	}
+}
+
 func TestMESIParseSimpleStaticContent(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/mesi/parser_test.go
+++ b/mesi/parser_test.go
@@ -405,13 +405,16 @@ func TestMESIParseWorkerPoolRespectsMaxWorkers(t *testing.T) {
 		t.Skip("skipping concurrency test in short mode")
 	}
 
-	var maxConcurrent atomic.Int64
-	var current atomic.Int64
+		var maxConcurrent atomic.Int64
+		var current atomic.Int64
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		v := current.Add(1)
-		if p := maxConcurrent.Load(); v > p {
-			maxConcurrent.CompareAndSwap(p, v)
+		for {
+			old := maxConcurrent.Load()
+			if v <= old || maxConcurrent.CompareAndSwap(old, v) {
+				break
+			}
 		}
 		time.Sleep(50 * time.Millisecond)
 		current.Add(-1)
@@ -438,6 +441,32 @@ func TestMESIParseWorkerPoolRespectsMaxWorkers(t *testing.T) {
 	mc := maxConcurrent.Load()
 	if mc > 2 {
 		t.Errorf("max concurrent includes = %d, want <= 2 (MaxWorkers=2)", mc)
+	}
+}
+
+func TestMESIParseMixedStaticAndESI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("INCLUDE:" + r.URL.Path))
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+
+	input := "prefix" +
+		`<!--esi <esi:include src="` + server.URL + `/first"/>-->` +
+		"middle" +
+		`<!--esi <esi:include src="` + server.URL + `/second"/>-->` +
+		"suffix"
+
+	result := MESIParse(input, config)
+	// Each <!--esi block adds a leading space from unescape
+	expected := "prefix INCLUDE:/firstmiddle INCLUDE:/secondsuffix"
+	if result != expected {
+		t.Errorf("MESIParse() = %q, want %q", result, expected)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes unbounded goroutine creation in MESIParse: one goroutine per token was spawned even for static content.

## Changes

- **Static tokens** processed synchronously in the main loop — zero goroutines
- **ESI tokens** dispatched through a bounded worker pool (default: NumCPU*4 workers)
- New `EsiParserConfig.MaxWorkers` field controls the pool size
- `TestMESIParseWorkerPoolRespectsMaxWorkers` verifies concurrency is bounded

## Testing

- `go test -race ./...` — all pass
- Goroutine leak verified via `goleak.VerifyTestMain`
</pre>