### PR TITLE
fix(apache): O(n²) body accumulation via apr_pstrcat in allowed_hosts loop (#91)

### DIFF
--- a/servers/apache/mod_mesi.c
+++ b/servers/apache/mod_mesi.c
@@ -283,9 +283,9 @@ static int mesi_response_filter(ap_filter_t *f, apr_bucket_brigade *bb) {
         char *p = buf;
         for (int i = 0; i < arr->nelts; i++) {
             if (i > 0) *p++ = ' ';
-            apr_size_t len = strlen(hosts[i]);
-            memcpy(p, hosts[i], len);
-            p += len;
+            apr_size_t host_len = strlen(hosts[i]);
+            memcpy(p, hosts[i], host_len);
+            p += host_len;
         }
         *p = '\0';
         allowed_hosts_str = buf;

--- a/servers/apache/mod_mesi.c
+++ b/servers/apache/mod_mesi.c
@@ -269,15 +269,26 @@ static int mesi_response_filter(ap_filter_t *f, apr_bucket_brigade *bb) {
         return ap_pass_brigade(f->next, ctx->bb);
     }
 
-    // Build allowed_hosts string from config
+    // Build allowed_hosts string from config (O(n) time, single allocation)
     char *allowed_hosts_str = "";
     if (conf->allowed_hosts && conf->allowed_hosts->nelts > 0) {
         apr_array_header_t *arr = conf->allowed_hosts;
         const char **hosts = (const char **)arr->elts;
-        allowed_hosts_str = apr_pstrdup(f->r->pool, hosts[0]);
-        for (int i = 1; i < arr->nelts; i++) {
-            allowed_hosts_str = apr_pstrcat(f->r->pool, allowed_hosts_str, " ", hosts[i], NULL);
+        apr_size_t total = 0;
+        for (int i = 0; i < arr->nelts; i++) {
+            total += strlen(hosts[i]);
+            if (i > 0) total++;
         }
+        char *buf = apr_palloc(f->r->pool, total + 1);
+        char *p = buf;
+        for (int i = 0; i < arr->nelts; i++) {
+            if (i > 0) *p++ = ' ';
+            apr_size_t len = strlen(hosts[i]);
+            memcpy(p, hosts[i], len);
+            p += len;
+        }
+        *p = '\0';
+        allowed_hosts_str = buf;
     }
 
     int block_private = (conf->block_private_ips != -1) ? conf->block_private_ips : 1;


### PR DESCRIPTION
## Summary

Fixes the remaining O(n²) `apr_pstrcat` pattern in `servers/apache/mod_mesi.c`. The main body accumulation was already fixed via `flatten_brigade()` with `apr_brigade_flatten`, but building `allowed_hosts_str` still used `apr_pstrcat` in a loop — same Shlemiel-the-Painter algorithm.

## Change

Replaced the incremental `apr_pstrcat` loop with a two-pass approach:
1. First pass: compute total length
2. Single `apr_palloc` allocation
3. Second pass: fill buffer with `memcpy` at the correct offset

**Before:** O(n²) time, N allocations, ~(N²)/2 bytes copied  
**After:** O(n) time, 1 allocation, exactly `total + 1` bytes

## Testing

All 23 Apache integration tests pass. The Docker build compiled without warnings.

Closes #91