### PR TITLE
fix(mesi): remove strings.Builder parameter from assembleResults (latent copy foot-gun)

### DIFF
--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -14,10 +14,17 @@ type Response struct {
 	index   int
 }
 
-func assembleResults(results []Response, result strings.Builder) string {
+func assembleResults(results []Response) string {
 	sort.SliceStable(results, func(i, j int) bool {
 		return results[i].index < results[j].index
 	})
+
+	var result strings.Builder
+	total := 0
+	for _, r := range results {
+		total += len(r.content)
+	}
+	result.Grow(total)
 
 	for _, res := range results {
 		result.WriteString(res.content)
@@ -51,7 +58,6 @@ func MESIParse(input string, config EsiParserConfig) string {
 	logger := config.getLogger()
 	start := time.Now()
 
-	var result strings.Builder
 	processed := unescape(input)
 	tokens := esiTokenizer(processed)
 
@@ -150,5 +156,5 @@ func MESIParse(input string, config EsiParserConfig) string {
 		wg.Wait()
 	}
 
-	return assembleResults(results, result)
+	return assembleResults(results)
 }

--- a/mesi/parser_test.go
+++ b/mesi/parser_test.go
@@ -433,7 +433,8 @@ func BenchmarkAssembleResults(b *testing.B) {
 	res := makeResponses(1000)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = assembleResults(res)
+		copied := append([]Response(nil), res...)
+		_ = assembleResults(copied)
 	}
 }
 

--- a/mesi/parser_test.go
+++ b/mesi/parser_test.go
@@ -413,12 +413,27 @@ func TestAssembleResults(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var builder strings.Builder
-			result := assembleResults(tt.results, builder)
+			result := assembleResults(tt.results)
 			if result != tt.expected {
 				t.Errorf("assembleResults() = %q, want %q", result, tt.expected)
 			}
 		})
+	}
+}
+
+func makeResponses(n int) []Response {
+	res := make([]Response, n)
+	for i := range res {
+		res[i] = Response{content: string(rune('a' + i%26)), index: n - i}
+	}
+	return res
+}
+
+func BenchmarkAssembleResults(b *testing.B) {
+	res := makeResponses(1000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = assembleResults(res)
 	}
 }
 
@@ -429,7 +444,7 @@ func TestAssembleResultsStableOrder(t *testing.T) {
 		for i := range inputs {
 			inputs[i] = Response{content: string(rune('a' + i%26)), index: 0}
 		}
-		out := assembleResults(append([]Response(nil), inputs...), strings.Builder{})
+		out := assembleResults(append([]Response(nil), inputs...))
 		var expected strings.Builder
 		for _, r := range inputs {
 			expected.WriteString(r.content)


### PR DESCRIPTION
## Summary

`assembleResults` took `strings.Builder` **by value**, which is a documented foot-gun in Go — calling `WriteString` on a copied builder panics if the original was already used. Currently the callsite passes a fresh builder so no panic occurs, but the API is fragile and misleading.

## Changes

- **`mesi/parser.go`**: `assembleResults` now takes only `[]Response`, allocates its own `strings.Builder` with `Grow` pre-sizing for efficiency
- **`mesi/parser_test.go`**: Updated both test functions to the new signature; added `BenchmarkAssembleResults` benchmark

Closes #113