### PR TITLE
fix(apache): clarify Test 3 assertion message (non-HTML content bypass)

### DIFF
--- a/docs/apache-integration-plan.md
+++ b/docs/apache-integration-plan.md
@@ -604,7 +604,7 @@ fi
 echo "=== Test 3: Non-HTML content ==="
 RESPONSE=$(curl -s http://localhost:8080/noesi.txt)
 if echo "$RESPONSE" | grep -q "esi:include"; then
-    echo "PASS: Non-HTML content not processed"
+    echo "PASS: Non-HTML content bypassed ESI filter (tags preserved verbatim)"
 else
     echo "FAIL: Non-HTML content was processed"
     echo "Response: $RESPONSE"

--- a/servers/apache/test.sh
+++ b/servers/apache/test.sh
@@ -30,7 +30,7 @@ fi
 echo "=== Test 3: Non-HTML content (text/plain) ==="
 RESPONSE=$(curl -s http://localhost:8080/noesi.txt)
 if echo "$RESPONSE" | grep -q "esi:include"; then
-    echo "PASS: Plain text content not processed"
+    echo "PASS: Plain text content bypassed ESI filter (tags preserved verbatim)"
 else
     echo "FAIL: Plain text content was processed"
     echo "Response: $RESPONSE"


### PR DESCRIPTION
Closes #135

## Summary
Reworded the Test 3 pass message in `servers/apache/test.sh` from `"PASS: Plain text content not processed"` to `"PASS: Plain text content bypassed ESI filter (tags preserved verbatim)"`.

The old message was ambiguous — "not processed" reads like the filter failed to do something, when in fact it correctly *declined* to process non-HTML content. Updated the same line in `docs/apache-integration-plan.md` for consistency.