### PR TITLE
fix(mesi): replace timing-dependent test assertions with deterministic synchronization (#116)

### DIFF
--- a/mesi/fetchUrl_test.go
+++ b/mesi/fetchUrl_test.go
@@ -322,14 +322,11 @@ func TestSingleFetchUrlWithNilContext(t *testing.T) {
 }
 
 func TestMESIParseContextPropagation(t *testing.T) {
+	handlerReached := make(chan struct{})
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		select {
-		case <-r.Context().Done():
-			return
-		case <-time.After(5 * time.Second):
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("SLOW_RESPONSE"))
-		}
+		close(handlerReached)
+		<-r.Context().Done()
 	}))
 	defer server.Close()
 
@@ -347,12 +344,12 @@ func TestMESIParseContextPropagation(t *testing.T) {
 
 	cancel()
 
-	start := time.Now()
 	result := MESIParse(html, config)
-	elapsed := time.Since(start)
 
-	if elapsed > 2*time.Second {
-		t.Errorf("MESIParse took too long (%v) - context not propagated properly", elapsed)
+	select {
+	case <-handlerReached:
+		t.Error("handler was reached despite cancelled context")
+	default:
 	}
 
 	if result == "" {
@@ -361,14 +358,11 @@ func TestMESIParseContextPropagation(t *testing.T) {
 }
 
 func TestMESIParseContextCancellationStopsAllGoroutines(t *testing.T) {
+	handlerReached := make(chan struct{})
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		select {
-		case <-r.Context().Done():
-			return
-		case <-time.After(5 * time.Second):
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("SLOW"))
-		}
+		close(handlerReached)
+		<-r.Context().Done()
 	}))
 	defer server.Close()
 
@@ -386,26 +380,26 @@ func TestMESIParseContextCancellationStopsAllGoroutines(t *testing.T) {
 
 	cancel()
 
-	start := time.Now()
 	result := MESIParse(html, config)
-	elapsed := time.Since(start)
 
-	if elapsed > 2*time.Second {
-		t.Errorf("MESIParse took too long (%v) with cancelled context", elapsed)
+	select {
+	case <-handlerReached:
+		t.Error("handler was reached despite cancelled context")
+	default:
 	}
 
 	_ = result
 }
 
 func TestMESIParseContextCancellationMidParse(t *testing.T) {
+	handlerReached := make(chan struct{})
+
 	slowServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
-		case <-r.Context().Done():
-			return
-		case <-time.After(5 * time.Second):
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("SLOW"))
+		case handlerReached <- struct{}{}:
+		default:
 		}
+		<-r.Context().Done()
 	}))
 	defer slowServer.Close()
 
@@ -439,17 +433,13 @@ func TestMESIParseContextCancellationMidParse(t *testing.T) {
 		done <- result
 	}()
 
-	// Cancel context after 100ms, while MESIParse is running
-	time.Sleep(100 * time.Millisecond)
+	// Wait for at least one slow handler to be reached, then cancel
+	<-handlerReached
 	cancel()
 
 	// Wait for MESIParse to return
-	select {
-	case result := <-done:
-		_ = result
-	case <-time.After(2 * time.Second):
-		t.Fatal("MESIParse did not return within 2 seconds after context cancellation")
-	}
+	result := <-done
+	_ = result
 }
 
 func TestFetchConcurrentBothSucceed(t *testing.T) {
@@ -584,9 +574,16 @@ func TestFetchConcurrentNoAltShortCircuit(t *testing.T) {
 }
 
 func TestFetchConcurrentContextCancellation(t *testing.T) {
+	handlerBlock := make(chan struct{})
+
 	slowServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(5 * time.Second)
-		w.WriteHeader(http.StatusOK)
+		select {
+		case <-r.Context().Done():
+			return
+		case <-handlerBlock:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK"))
+		}
 	}))
 	defer slowServer.Close()
 
@@ -601,13 +598,11 @@ func TestFetchConcurrentContextCancellation(t *testing.T) {
 		BlockPrivateIPs: false,
 	}
 
-	start := time.Now()
 	html := `<html><esi:include src="` + slowServer.URL + `/slow1" alt="` + slowServer.URL + `/slow2" fetch-mode="concurrent" /></html>`
-	_ = MESIParse(html, config)
-	elapsed := time.Since(start)
+	result := MESIParse(html, config)
 
-	if elapsed > 1*time.Second {
-		t.Errorf("fetchConcurrent took too long (%v) with cancelled context", elapsed)
+	if strings.Contains(result, "OK") {
+		t.Errorf("expected empty result due to context cancellation, got %q", result)
 	}
 }
 

--- a/mesi/include.go
+++ b/mesi/include.go
@@ -78,7 +78,7 @@ func (token *esiIncludeToken) parseAB() abRatio {
 	}
 }
 
-func (ratio abRatio) selectUrl(token *esiIncludeToken) string {
+func (ratio abRatio) selectUrl(token *esiIncludeToken, rng func(int) int) string {
 	if token.Alt == "" {
 		return token.Src
 	}
@@ -89,7 +89,11 @@ func (ratio abRatio) selectUrl(token *esiIncludeToken) string {
 		return token.Src
 	}
 
-	randomValue := rand.IntN(int(sum))
+	if rng == nil {
+		rng = rand.IntN
+	}
+
+	randomValue := rng(int(sum))
 
 	if randomValue < int(ratio.A) {
 		return token.Src
@@ -99,7 +103,7 @@ func (ratio abRatio) selectUrl(token *esiIncludeToken) string {
 
 func fetchAB(token *esiIncludeToken, config EsiParserConfig) (string, bool, error) {
 	logger := config.getLogger()
-	selected := token.parseAB().selectUrl(token)
+	selected := token.parseAB().selectUrl(token, nil)
 	logger.Debug("ab_ratio_select", "src", token.Src, "alt", token.Alt, "selected", selected)
 	return singleFetchUrlWithContext(selected, config, config.Context)
 }

--- a/mesi/include_test.go
+++ b/mesi/include_test.go
@@ -174,34 +174,57 @@ func TestParseABInvalidRatioDefaults(t *testing.T) {
 
 func TestSelectUrlChoosesBasedOnRatio(t *testing.T) {
 	token := &esiIncludeToken{Src: "/src.html", Alt: "/alt.html"}
-	ratio := abRatio{A: 80, B: 20}
 
-	srcCount := 0
-	altCount := 0
-	iterations := 10000
-
-	for i := 0; i < iterations; i++ {
-		selected := ratio.selectUrl(token)
-		switch selected {
-		case "/src.html":
-			srcCount++
-		case "/alt.html":
-			altCount++
-		default:
-			t.Fatalf("unexpected URL: %q", selected)
+	t.Run("rng_in_a_range_selects_src", func(t *testing.T) {
+		ratio := abRatio{A: 80, B: 20}
+		for i := 0; i < 80; i++ {
+			rng := func(int) int { return i }
+			selected := ratio.selectUrl(token, rng)
+			if selected != "/src.html" {
+				t.Errorf("rng=%d: expected src, got %q", i, selected)
+			}
 		}
-	}
+	})
 
-	srcPercent := float64(srcCount) / float64(iterations) * 100
-	if srcPercent < 65 || srcPercent > 95 {
-		t.Errorf("src selected %.1f%%, expected 65-95%% (target 80%%)", srcPercent)
-	}
+	t.Run("rng_in_b_range_selects_alt", func(t *testing.T) {
+		ratio := abRatio{A: 80, B: 20}
+		for i := 80; i < 100; i++ {
+			rng := func(int) int { return i }
+			selected := ratio.selectUrl(token, rng)
+			if selected != "/alt.html" {
+				t.Errorf("rng=%d: expected alt, got %q", i, selected)
+			}
+		}
+	})
+
+	t.Run("no_alt_returns_src_regardless_of_rng", func(t *testing.T) {
+		noAltToken := &esiIncludeToken{Src: "/src.html", Alt: ""}
+		ratio := abRatio{A: 50, B: 50}
+		for _, v := range []int{0, 49, 50, 99} {
+			rng := func(int) int { return v }
+			selected := ratio.selectUrl(noAltToken, rng)
+			if selected != "/src.html" {
+				t.Errorf("rng=%d: expected src when no alt, got %q", v, selected)
+			}
+		}
+	})
+
+	t.Run("zero_sum_returns_src", func(t *testing.T) {
+		ratio := abRatio{A: 0, B: 0}
+		for _, v := range []int{0, 50} {
+			rng := func(int) int { return v }
+			selected := ratio.selectUrl(token, rng)
+			if selected != "/src.html" {
+				t.Errorf("rng=%d: expected src when sum=0, got %q", v, selected)
+			}
+		}
+	})
 }
 
 func TestSelectUrlNoAltReturnsSrc(t *testing.T) {
 	token := &esiIncludeToken{Src: "/src.html", Alt: ""}
 	ratio := abRatio{A: 50, B: 50}
-	selected := ratio.selectUrl(token)
+	selected := ratio.selectUrl(token, nil)
 	if selected != "/src.html" {
 		t.Errorf("selectUrl() = %q, want %q", selected, "/src.html")
 	}

--- a/mesi/parser_test.go
+++ b/mesi/parser_test.go
@@ -363,10 +363,16 @@ func TestMESIParseRespectsMaxDepth(t *testing.T) {
 }
 
 func TestMESIParseRespectsTimeout(t *testing.T) {
+	handlerBlock := make(chan struct{})
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(500 * time.Millisecond)
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("content"))
+		select {
+		case <-r.Context().Done():
+			return
+		case <-handlerBlock:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("content"))
+		}
 	}))
 	defer server.Close()
 


### PR DESCRIPTION
## Summary

Fixes #116 — removes all timing-dependent assertions (`elapsed > N`, `time.Sleep`) from the mesi test suite and replaces them with deterministic channel-based synchronization.

### Changes

**`mesi/include.go`** — Added `rng func(int) int` parameter to `selectUrl()`. When `nil`, falls back to `rand.IntN`. Enables deterministic RNG injection in tests.

**`mesi/fetchUrl_test.go`** — Fixed 4 tests:
- `TestMESIParseContextPropagation` — replaced `elapsed > 2s` with `handlerReached` channel (handler must NOT be reached when context is pre-cancelled)
- `TestMESIParseContextCancellationStopsAllGoroutines` — same pattern
- `TestMESIParseContextCancellationMidParse` — replaced `time.Sleep(100ms)` + `<-time.After(2s)` with `<-handlerReached -> cancel() -> <-done`
- `TestFetchConcurrentContextCancellation` — replaced `time.Sleep(5s)` + `elapsed > 1s` with `select` on `r.Context().Done()`

**`mesi/include_test.go`** — Fixed `TestSelectUrlChoosesBasedOnRatio`:
- Replaced statistical 10000-iteration 65-95% range check with 4 deterministic subtests using injected RNG

**`mesi/parser_test.go`** — Fixed `TestMESIParseRespectsTimeout`:
- Replaced `time.Sleep(500ms)` with `select` on `r.Context().Done()` + `handlerBlock` channel

### Verification
- `go vet ./...` — clean
- `go test -race ./...` — all pass (mesi + middleware)