### PR TITLE
fix(apache): add .gitignore with allowlist for test fixtures and harden backend mount (#100)

### DIFF
--- a/servers/apache/docker-compose.yml
+++ b/servers/apache/docker-compose.yml
@@ -21,9 +21,10 @@ services:
 
   backend:
     image: python:3.11-slim
+    user: "${UID:-1000}:${GID:-1000}"
     working_dir: /data
     volumes:
-      - ./tests:/data
+      - ./tests:/data:ro
     command: python -m http.server 8000
     expose:
       - "8000"

--- a/servers/apache/tests/.gitignore
+++ b/servers/apache/tests/.gitignore
@@ -1,0 +1,17 @@
+*
+!.gitignore
+!allowed.txt
+!comment.html
+!fallback.html
+!include.txt
+!index.html
+!large.html
+!nested.html
+!nested.txt
+!noesi.css
+!noesi.json
+!noesi.txt
+!remove.html
+!ssrf-allowed.html
+!ssrf-blocked.html
+!ssrf-localhost.html


### PR DESCRIPTION
## Summary

- Remove stray `test.txt` artifact (root-owned, from Docker container leak)
- Add `servers/apache/tests/.gitignore` with deny-all + allowlist of known fixture files
- Make backend volume `:ro` so containers cannot write to the host
- Run Python backend as non-root (`user: "${UID:-1000}:${GID:-1000}"`)

## Testing

- `touch servers/apache/tests/test.txt && git status` → clean tree (.gitignore catches it)
- `docker compose exec backend touch /data/junk` → fails with Read-only file system

Closes #100