### PR TITLE
[mesi] Remove dead branch in EsiParserConfig.DecreaseMaxDepth

### DIFF
--- a/mesi/config.go
+++ b/mesi/config.go
@@ -107,9 +107,7 @@ func (c EsiParserConfig) ParseOnly() bool {
 
 func (c EsiParserConfig) DecreaseMaxDepth() EsiParserConfig {
 	if c.MaxDepth > 0 {
-		c.MaxDepth = c.MaxDepth - 1
-	} else {
-		c.MaxDepth = 0
+		c.MaxDepth--
 	}
 
 	return c

--- a/mesi/config_test.go
+++ b/mesi/config_test.go
@@ -1,6 +1,7 @@
 package mesi
 
 import (
+	"math"
 	"testing"
 	"time"
 )
@@ -89,6 +90,7 @@ func TestDecreaseMaxDepth(t *testing.T) {
 		{"decrease from five", 5, 4},
 		{"decrease from one", 1, 0},
 		{"stay at zero", 0, 0},
+		{"decrease from max uint", math.MaxUint, math.MaxUint - 1},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #112

## Summary

- Removed unreachable `else` branch in `DecreaseMaxDepth` — `MaxDepth` is `uint`, so the `else` (`c.MaxDepth = 0`) was a no-op
- Changed `c.MaxDepth = c.MaxDepth - 1` to idiomatic `c.MaxDepth--`
- Added boundary test case: `math.MaxUint → math.MaxUint - 1` to document no-wraparound intent

All existing tests pass.