### PR TITLE
fix(mesi): correct placeholder names in Parse deprecation comment

### DIFF
--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -33,7 +33,14 @@ func assembleResults(results []Response) string {
 	return result.String()
 }
 
-// Deprecated: FunctionName is deprecated, please use mEsiParse
+// Deprecated: Parse is deprecated; use MESIParse with EsiParserConfig instead.
+//
+// Migration:
+//
+//	cfg := mesi.CreateDefaultConfig()
+//	cfg.DefaultUrl = defaultUrl
+//	cfg.MaxDepth = uint(maxDepth)
+//	result := mesi.MESIParse(input, cfg)
 func Parse(input string, maxDepth int, defaultUrl string) string {
 	config := EsiParserConfig{
 		Context:         context.Background(),


### PR DESCRIPTION
Fixes placeholder names in the `// Deprecated:` comment on `Parse`:

- `FunctionName` → `Parse` (correct function name)
- `mEsiParse` → `MESIParse` (correct replacement name)

Added a short migration example in the godoc.

`go vet ./...` — passes
`go test ./mesi/...` — all tests pass

Closes #108