### PR TITLE
docs: add feature matrix for all server integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
 - **esi:include timeout** - Timeout can be set both globally and specifically for a selected `esi:include` tag. In combination with fallback content, you can easily manage the page generation time.
 - **Fallback content** - Set the content to be displayed if remote content download fails.
 - **SSRF Protection** – Built-in protection against Server-Side Request Forgery attacks with private IP blocking and optional host whitelisting.
+
+See the full [Feature Matrix](docs/features.md) for a detailed breakdown of which features are supported in each server integration.
+
 ## ESI Parser Configuration
 This document describes the configuration structure for the mESI parser.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,55 @@
+# mESI – Feature Matrix
+
+Support status of mESI features across all server integrations.
+
+| Feature | mESI Core | Traefik | RoadRunner | Caddy / FrankenPHP | Nginx | Apache | PHP Extension | CLI | Proxy |
+|---|---|---|---|---|---|---|---|---|---|
+| `<esi:include>` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `<esi:remove>` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `<esi:comment>` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `<!--esi ... -->` (inline) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `<esi:inline>`, `<esi:choose>`, `<esi:try>`, `<esi:vars>` | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
+| `src` / `alt` attributes | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `fetch-mode="fallback"` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `fetch-mode="ab"` (A/B testing) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `ab-ratio` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `fetch-mode="concurrent"` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `timeout` (per-tag) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `max-depth` (per-tag) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `onerror="continue"` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Fallback content (tag body) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `IncludeErrorMarker` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ⚠️ | ✅ |
+| Global MaxDepth | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| Global Timeout | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
+| SSRF (BlockPrivateIPs) | ✅ | 🔒 | 🔒 | 🔒 | ❌ | ✅ | ❌ | 🔒 | ✅ |
+| AllowedHosts | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ |
+| AllowPrivateIPsForAllowedHosts | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| MaxResponseSize | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| MaxConcurrentRequests | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| MaxWorkers | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| ParseOnHeader | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Debug mode | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Cache (in-memory) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Cache (Redis) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Cache (Memcached) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Custom CacheKeyFunc | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Recursive ESI processing | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Shared HTTPClient | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+
+## Legend
+
+| Symbol | Meaning |
+|---|---|
+| ✅ | Supported and configurable |
+| 🔒 | Always on (hardcoded, not configurable) |
+| ⚠️ | Partial support / limitations |
+| ❌ | Not supported / unavailable |
+
+## Notes
+
+- **`<esi:inline>`, `<esi:choose>`, `<esi:try>`, `<esi:vars>`** – Recognized by the tokenizer (no parse errors), but their content is silently dropped from output. Full support planned.
+- **Nginx** – Uses the `Parse` function from `libgomesi` which does not enable `BlockPrivateIPs` (defaults to `false`). No SSRF protection.
+- **PHP Extension** – Exposes only `\mesi\parse(input, max_depth, default_url)`. No security configuration.
+- **Caddy / FrankenPHP** – FrankenPHP uses the Caddy plugin, identical functionality.
+- **Proxy** – Accepts full `EsiParserConfig`; all features available when provided by calling code.
+- **IncludeErrorMarker (CLI)** – Can only be set programmatically (no CLI flag).


### PR DESCRIPTION
## Summary

- Adds `docs/features.md` — a table showing which mESI features are supported, configurable, hardcoded, or unavailable across all 8 integrations (Traefik, RoadRunner, Caddy/FrankenPHP, Nginx, Apache, PHP Extension, CLI, Proxy).
- Links the feature matrix from `README.md`.

The table uses four status symbols: ✅ (supported & configurable), 🔒 (always on, hardcoded), ⚠️ (partial), ❌ (unavailable).

## Notable findings captured in the matrix

- **Nginx** and **PHP Extension** have no SSRF protection (`Parse` from libgomesi leaves `BlockPrivateIPs` at default `false`).
- **Apache** is the only C-based server integration that exposes `AllowedHosts` and configurable `BlockPrivateIPs`.
- **RoadRunner** and **Caddy** have all config hardcoded (even `MaxDepth`).
- Only **Proxy** and **CLI** expose the full `EsiParserConfig`.