### PR TITLE
[core] Implement <esi:try>, <esi:attempt>, <esi:except> (#163)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libgomesi (0.6.0) unstable; urgency=medium
+
+  * Add `<esi:try>`, `<esi:attempt>`, `<esi:except>` support
+  * Fix tokenizer nesting handling for block tags (try, choose, inline)
+
+ -- Piotr Halas <halaspiotr@gmail.com>  Mon, 18 May 2026 18:00:00 +0200
+
 libgomesi (0.5.1) unstable; urgency=medium
 
   * add libgomesi and libgomes-dev

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,7 +8,9 @@ Support status of mESI features across all server integrations.
 | `<esi:remove>` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `<esi:comment>` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `<!--esi ... -->` (inline) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `<esi:inline>`, `<esi:choose>`, `<esi:try>` | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
+| `<esi:inline>` | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
+| `<esi:choose>`, `<esi:when>`, `<esi:otherwise>` | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
+| `<esi:try>`, `<esi:attempt>`, `<esi:except>` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `<esi:vars>` / `$(...)` variable substitution | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `src` / `alt` attributes | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `fetch-mode="fallback"` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -48,7 +50,9 @@ Support status of mESI features across all server integrations.
 
 ## Notes
 
-- **`<esi:inline>`, `<esi:choose>`, `<esi:try>`** – Recognized by the tokenizer (no parse errors), but their content is silently dropped from output. Full support planned.
+- **`<esi:inline>`** – Recognized by the tokenizer (no parse errors), but content is silently dropped from output. Full support planned.
+- **`<esi:choose>`, `<esi:when>`, `<esi:otherwise>`** – Recognized by the tokenizer (no parse errors), but content is silently dropped from output. Full support planned.
+- **`<esi:try>`, `<esi:attempt>`, `<esi:except>`** – Fully supported. Unhandled include errors within `<esi:attempt>` trigger `<esi:except>` rendering. `onerror="continue"` and fallback body do NOT trigger `<esi:except>`. Supports nested `<esi:try>` blocks.
 - **`<esi:vars>` / `$(...)` variable substitution** – Fully supported. Variables are defined via `<esi:variable>` in `<esi:vars>` blocks and resolved via `$(NAME)` syntax in include URLs, text content, and test expressions. Supports `$(HTTP_HEADER{Name})`, `$(HTTP_COOKIE{name})`, and `$(QUERY_STRING{param})` via config fields.
 - **Nginx** – Uses the `Parse` function from `libgomesi` which does not enable `BlockPrivateIPs` (defaults to `false`). No SSRF protection.
 - **PHP Extension** – Exposes only `\mesi\parse(input, max_depth, default_url)`. No security configuration.

--- a/mesi/include.go
+++ b/mesi/include.go
@@ -3,6 +3,7 @@ package mesi
 import (
 	"encoding/xml"
 	"errors"
+	"fmt"
 )
 
 type esiResponse struct {
@@ -33,11 +34,12 @@ func parseInclude(input string) (token esiIncludeToken, err error) {
 	return esi, nil
 }
 
-func (token *esiIncludeToken) toString(config EsiParserConfig) (string, bool) {
+func (token *esiIncludeToken) toString(config EsiParserConfig) (string, bool, error) {
 	logger := config.getLogger()
 	var data string
 	var err error
 	var isEsiResponse bool
+	var unhandledErr error
 
 	logger.Debug("include_start", "src", token.Src, "fetch_mode", token.FetchMode, "max_depth", config.MaxDepth, "timeout", config.Timeout)
 
@@ -59,15 +61,16 @@ func (token *esiIncludeToken) toString(config EsiParserConfig) (string, bool) {
 		logger.Debug("include_failed", "src", token.Src, "error", err.Error())
 
 		if token.OnError == "continue" {
-			return "", false
+			return "", false, nil
 		}
 
 		if token.Content != "" {
-			return token.Content, false
+			return token.Content, false, nil
 		}
 
-		return config.IncludeErrorMarker, false
+		unhandledErr = fmt.Errorf("include failed: %w", err)
+		return config.IncludeErrorMarker, false, unhandledErr
 	}
 
-	return data, isEsiResponse
+	return data, isEsiResponse, nil
 }

--- a/mesi/include_test.go
+++ b/mesi/include_test.go
@@ -151,7 +151,7 @@ func TestToStringErrorDoesNotLeakInternalDetails(t *testing.T) {
 	config.BlockPrivateIPs = false
 	config.Logger = log
 
-	data, _ := token.toString(config)
+	data, _, _ := token.toString(config)
 	if data != "" {
 		t.Errorf("toString() = %q, want empty string (no error leak)", data)
 	}
@@ -182,9 +182,12 @@ func TestIncludeErrorMarkerCustom(t *testing.T) {
 	config.BlockPrivateIPs = false
 	config.IncludeErrorMarker = "<!-- esi error -->"
 
-	data, _ := token.toString(config)
+	data, _, err := token.toString(config)
 	if data != "<!-- esi error -->" {
 		t.Errorf("toString() = %q, want %q", data, "<!-- esi error -->")
+	}
+	if err == nil {
+		t.Error("toString() expected error for unhandled include failure")
 	}
 }
 
@@ -204,9 +207,12 @@ func TestToStringWithOnerrorContinue(t *testing.T) {
 	config.MaxDepth = 1
 	config.BlockPrivateIPs = false
 
-	data, _ := token.toString(config)
+	data, _, err := token.toString(config)
 	if data != "" {
 		t.Errorf("toString() = %q, want empty string (onerror=continue)", data)
+	}
+	if err != nil {
+		t.Errorf("toString() unexpected error for onerror=continue: %v", err)
 	}
 }
 
@@ -226,9 +232,12 @@ func TestToStringWithFallbackContent(t *testing.T) {
 	config.MaxDepth = 1
 	config.BlockPrivateIPs = false
 
-	data, _ := token.toString(config)
+	data, _, err := token.toString(config)
 	if data != "fallback content" {
 		t.Errorf("toString() = %q, want %q", data, "fallback content")
+	}
+	if err != nil {
+		t.Errorf("toString() unexpected error for fallback content: %v", err)
 	}
 }
 
@@ -249,9 +258,12 @@ func TestToStringWithMaxDepthExceeded(t *testing.T) {
 	config.BlockPrivateIPs = false
 	config.Logger = log
 
-	data, _ := token.toString(config)
+	data, _, err := token.toString(config)
 	if data != "" {
 		t.Errorf("toString() = %q, want empty string (no error leak)", data)
+	}
+	if err == nil {
+		t.Error("toString() expected error for max depth exceeded")
 	}
 	if !log.containsMsg("include_failed") {
 		t.Error("expected include_failed log entry")

--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -9,12 +9,6 @@ import (
 	"time"
 )
 
-// esiTryResult holds the result of processing a try block.
-type esiTryResult struct {
-	content string
-	hasError bool
-}
-
 type Response struct {
 	content string
 	index   int

--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -9,6 +9,12 @@ import (
 	"time"
 )
 
+// esiTryResult holds the result of processing a try block.
+type esiTryResult struct {
+	content string
+	hasError bool
+}
+
 type Response struct {
 	content string
 	index   int
@@ -97,6 +103,9 @@ func MESIParse(input string, config EsiParserConfig) string {
 				}
 			}
 			results = append(results, Response{"", index})
+		} else if token.esiTagType == ESI_TRY {
+			content := processTryBlock(token.esiTagContent, config, start)
+			results = append(results, Response{content, index})
 		} else if !token.isEsi() {
 			content := evaluateExpression(token.staticContent, config)
 			results = append(results, Response{content, index})
@@ -142,7 +151,7 @@ func MESIParse(input string, config EsiParserConfig) string {
 						include.Src = evaluateExpression(include.Src, config)
 						include.Alt = evaluateExpression(include.Alt, config)
 						newConfig := config.OverrideConfig(include).WithElapsedTime(time.Since(start))
-						content, isEsiResponse := include.toString(newConfig)
+						content, isEsiResponse, _ := include.toString(newConfig)
 
 						if config.CanGoDeeper(time.Since(start)) && (isEsiResponse || !newConfig.ParseOnHeader) {
 							content = MESIParse(content, newConfig.DecreaseMaxDepth().WithElapsedTime(time.Since(start)))
@@ -177,4 +186,289 @@ func MESIParse(input string, config EsiParserConfig) string {
 	}
 
 	return assembleResults(results)
+}
+
+// extractTryBlocks extracts the attempt and except body content from a raw
+// <esi:try> tag content (e.g. "<esi:try><esi:attempt>...</esi:attempt>...").
+// Properly handles nested <esi:try> blocks by tracking nesting depth.
+// Returns the attempt body and except body (exceptBody is empty if absent).
+func extractTryBlocks(raw string) (attemptBody, exceptBody string) {
+	// Skip past the opening <esi:try ...>
+	closeBracket := strings.Index(raw, ">")
+	if closeBracket == -1 {
+		return "", ""
+	}
+	pos := closeBracket + 1
+
+	// Find first <esi:attempt> that is a direct child of this try block.
+	// Skip over any nested <esi:try>...</esi:try> blocks.
+	for {
+		nextTry := strings.Index(raw[pos:], "<esi:try")
+		nextAttempt := strings.Index(raw[pos:], "<esi:attempt")
+		if nextAttempt == -1 {
+			return "", ""
+		}
+		if nextTry != -1 && nextTry < nextAttempt {
+			nestedEnd := findTryClose(raw[pos+nextTry:])
+			if nestedEnd == -1 {
+				return "", ""
+			}
+			pos += nextTry + nestedEnd
+			continue
+		}
+		pos += nextAttempt
+		break
+	}
+
+	// Find end of <esi:attempt ...>
+	tagEnd := strings.Index(raw[pos:], ">")
+	if tagEnd == -1 {
+		return "", ""
+	}
+	pos += tagEnd + 1
+
+	// Find matching </esi:attempt>
+	attemptLen := findAttemptClose(raw[pos:])
+	if attemptLen == -1 {
+		attemptBody = raw[pos:]
+		return attemptBody, ""
+	}
+	attemptBody = raw[pos : pos+attemptLen]
+	pos += attemptLen + len("</esi:attempt>")
+
+	// Check for <esi:except>
+	exceptStart := strings.Index(raw[pos:], "<esi:except")
+	if exceptStart == -1 {
+		return attemptBody, ""
+	}
+	pos += exceptStart
+	tagEnd = strings.Index(raw[pos:], ">")
+	if tagEnd == -1 {
+		return attemptBody, ""
+	}
+	pos += tagEnd + 1
+
+	exceptLen := findExceptClose(raw[pos:])
+	if exceptLen == -1 {
+		return attemptBody, ""
+	}
+	exceptBody = raw[pos : pos+exceptLen]
+
+	return attemptBody, exceptBody
+}
+
+// findAttemptClose finds the position (relative to s) of the </esi:attempt>
+// that matches the first <esi:attempt> in the content. s starts after the
+// opening <esi:attempt ...> tag. Handles nested <esi:try> and <esi:attempt>
+// blocks by tracking nesting depth.
+func findAttemptClose(s string) int {
+	depth := 0
+	pos := 0
+	for {
+		nextClose := strings.Index(s[pos:], "</esi:attempt>")
+		nextCloseTry := strings.Index(s[pos:], "</esi:try>")
+		firstClose := -1
+		if nextClose != -1 && (nextCloseTry == -1 || nextClose < nextCloseTry) {
+			firstClose = nextClose
+		} else if nextCloseTry != -1 {
+			firstClose = nextCloseTry
+		} else if nextClose != -1 {
+			firstClose = nextClose
+		}
+		if firstClose == -1 {
+			return -1
+		}
+
+		nextOpenAttempt := strings.Index(s[pos:], "<esi:attempt")
+		nextOpenTry := strings.Index(s[pos:], "<esi:try")
+		firstOpen := -1
+		if nextOpenAttempt != -1 && (nextOpenTry == -1 || nextOpenAttempt < nextOpenTry) {
+			firstOpen = nextOpenAttempt
+		} else if nextOpenTry != -1 {
+			firstOpen = nextOpenTry
+		} else if nextOpenAttempt != -1 {
+			firstOpen = nextOpenAttempt
+		}
+
+		if firstOpen != -1 && firstOpen < firstClose {
+			depth++
+			nextEnd := strings.Index(s[pos+firstOpen:], ">")
+			if nextEnd == -1 {
+				return -1
+			}
+			pos += firstOpen + nextEnd + 1
+			continue
+		}
+
+		if depth == 0 && firstClose == nextClose {
+			return pos + nextClose
+		}
+		depth--
+		var skipLen int
+		if firstClose == nextClose {
+			skipLen = len("</esi:attempt>")
+		} else {
+			skipLen = len("</esi:try>")
+		}
+		pos += firstClose + skipLen
+	}
+}
+
+// findExceptClose finds the position (relative to s) of the </esi:except>
+// that matches the first <esi:except> in the content. s starts after the
+// opening <esi:except ...> tag. Handles nested blocks.
+func findExceptClose(s string) int {
+	depth := 0
+	pos := 0
+	for {
+		nextClose := strings.Index(s[pos:], "</esi:except>")
+		nextCloseTry := strings.Index(s[pos:], "</esi:try>")
+		firstClose := -1
+		if nextClose != -1 && (nextCloseTry == -1 || nextClose < nextCloseTry) {
+			firstClose = nextClose
+		} else if nextCloseTry != -1 {
+			firstClose = nextCloseTry
+		} else if nextClose != -1 {
+			firstClose = nextClose
+		}
+		if firstClose == -1 {
+			return -1
+		}
+
+		nextOpenExcept := strings.Index(s[pos:], "<esi:except")
+		nextOpenTry := strings.Index(s[pos:], "<esi:try")
+		firstOpen := -1
+		if nextOpenExcept != -1 && (nextOpenTry == -1 || nextOpenExcept < nextOpenTry) {
+			firstOpen = nextOpenExcept
+		} else if nextOpenTry != -1 {
+			firstOpen = nextOpenTry
+		} else if nextOpenExcept != -1 {
+			firstOpen = nextOpenExcept
+		}
+
+		if firstOpen != -1 && firstOpen < firstClose {
+			depth++
+			nextEnd := strings.Index(s[pos+firstOpen:], ">")
+			if nextEnd == -1 {
+				return -1
+			}
+			pos += firstOpen + nextEnd + 1
+			continue
+		}
+
+		if depth == 0 && firstClose == nextClose {
+			return pos + nextClose
+		}
+		depth--
+		var skipLen int
+		if firstClose == nextClose {
+			skipLen = len("</esi:except>")
+		} else {
+			skipLen = len("</esi:try>")
+		}
+		pos += firstClose + skipLen
+	}
+}
+
+// findTryClose finds the position (relative to s) of the </esi:try>
+// that matches the first <esi:try> in s. s starts at the opening
+// <esi:try tag. Handles nested <esi:try> blocks.
+func findTryClose(s string) int {
+	depth := 0
+	pos := 0
+	for {
+		nextClose := strings.Index(s[pos:], "</esi:try>")
+		if nextClose == -1 {
+			return -1
+		}
+
+		nextOpen := strings.Index(s[pos:], "<esi:try")
+		if nextOpen != -1 && nextOpen < nextClose {
+			depth++
+			nextEnd := strings.Index(s[pos+nextOpen:], ">")
+			if nextEnd == -1 {
+				return -1
+			}
+			pos += nextOpen + nextEnd + 1
+			continue
+		}
+
+		if depth == 0 {
+			return pos + nextClose
+		}
+		depth--
+		pos += nextClose + len("</esi:try>")
+	}
+}
+
+// processTryBlock handles a <esi:try> block. It processes the attempt body
+// with error tracking. If any include inside attempt fails with an unhandled
+// error (no onerror="continue" and no fallback body), the except body is
+// rendered instead. If no except body exists, empty output is returned.
+func processTryBlock(raw string, config EsiParserConfig, start time.Time) string {
+	logger := config.getLogger()
+	attemptBody, exceptBody := extractTryBlocks(raw)
+
+	if attemptBody == "" {
+		logger.Debug("try_empty_attempt", "raw_length", len(raw))
+		return ""
+	}
+
+	result, hasError := processAttemptContent(attemptBody, config, start)
+
+	if hasError {
+		logger.Debug("try_attempt_failed_rendering_except")
+		if exceptBody != "" {
+			return MESIParse(exceptBody, config)
+		}
+		return ""
+	}
+
+	return result
+}
+
+// processAttemptContent processes content inside an <esi:attempt> block.
+// It tokenizes and processes includes inline (not via worker pool) to detect
+// unhandled include errors. Returns the rendered output and a flag indicating
+// whether an unhandled error occurred.
+func processAttemptContent(content string, config EsiParserConfig, start time.Time) (string, bool) {
+	tokens := esiTokenizer(content)
+
+	var hasError bool
+	var results []Response
+
+	for index, token := range tokens {
+		if token.esiTagType == ESI_INCLUDE {
+			include, err := parseInclude(token.esiTagContent)
+			if err != nil {
+				hasError = true
+				break
+			}
+			include.Src = evaluateExpression(include.Src, config)
+			include.Alt = evaluateExpression(include.Alt, config)
+			newConfig := config.OverrideConfig(include).WithElapsedTime(time.Since(start))
+			data, isEsiResponse, includeErr := include.toString(newConfig)
+
+			if includeErr != nil {
+				hasError = true
+				break
+			}
+
+			if config.CanGoDeeper(time.Since(start)) && (isEsiResponse || !newConfig.ParseOnHeader) {
+				data = MESIParse(data, newConfig.DecreaseMaxDepth().WithElapsedTime(time.Since(start)))
+			}
+
+			results = append(results, Response{data, index})
+		} else if token.esiTagType == ESI_TRY {
+			data := processTryBlock(token.esiTagContent, config, start)
+			results = append(results, Response{data, index})
+		} else if !token.isEsi() {
+			content := evaluateExpression(token.staticContent, config)
+			results = append(results, Response{content, index})
+		} else {
+			results = append(results, Response{"", index})
+		}
+	}
+
+	return assembleResults(results), hasError
 }

--- a/mesi/parser_test.go
+++ b/mesi/parser_test.go
@@ -498,3 +498,430 @@ func TestMESIParseNestedIncludes(t *testing.T) {
 		t.Errorf("MESIParse() = %q, want %q", result, "  inner content")
 	}
 }
+
+func TestExtractTryBlocks(t *testing.T) {
+	tests := []struct {
+		name              string
+		input             string
+		wantAttempt       string
+		wantExcept        string
+	}{
+		{
+			name:        "no attempt tag",
+			input:       "<esi:try>hello</esi:try>",
+			wantAttempt: "",
+			wantExcept:  "",
+		},
+		{
+			name:        "attempt only",
+			input:       "<esi:try><esi:attempt>hello</esi:attempt></esi:try>",
+			wantAttempt: "hello",
+			wantExcept:  "",
+		},
+		{
+			name:        "attempt and except",
+			input:       "<esi:try><esi:attempt>body</esi:attempt><esi:except>fallback</esi:except></esi:try>",
+			wantAttempt: "body",
+			wantExcept:  "fallback",
+		},
+		{
+			name:        "attempt with nested content",
+			input:       "<esi:try><esi:attempt><esi:include src=\"/x\"/></esi:attempt><esi:except>err</esi:except></esi:try>",
+			wantAttempt: "<esi:include src=\"/x\"/>",
+			wantExcept:  "err",
+		},
+		{
+			name:        "empty attempt",
+			input:       "<esi:try><esi:attempt></esi:attempt><esi:except>fallback</esi:except></esi:try>",
+			wantAttempt: "",
+			wantExcept:  "fallback",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attempt, except := extractTryBlocks(tt.input)
+			if attempt != tt.wantAttempt {
+				t.Errorf("attempt = %q, want %q", attempt, tt.wantAttempt)
+			}
+			if except != tt.wantExcept {
+				t.Errorf("except = %q, want %q", except, tt.wantExcept)
+			}
+		})
+	}
+}
+
+func TestESITrySuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("attempt content"))
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+
+	input := `<esi:try>
+	<esi:attempt>
+		<esi:include src="` + server.URL + `/ok"/>
+	</esi:attempt>
+	<esi:except>
+		except content
+	</esi:except>
+</esi:try>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "attempt content") {
+		t.Errorf("expected attempt content, got %q", result)
+	}
+	if strings.Contains(result, "except content") {
+		t.Errorf("except content should NOT be rendered on success, got %q", result)
+	}
+}
+
+func TestESITryFailure404(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("not found"))
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+
+	input := `<esi:try>
+	<esi:attempt>
+		<esi:include src="` + server.URL + `/missing"/>
+	</esi:attempt>
+	<esi:except>
+		fallback content
+	</esi:except>
+</esi:try>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "fallback content") {
+		t.Errorf("expected except content, got %q", result)
+	}
+	if strings.Contains(result, "not found") {
+		t.Errorf("attempt content should NOT be rendered on failure, got %q", result)
+	}
+}
+
+func TestESITryFailureTimeout(t *testing.T) {
+	handlerBlock := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-handlerBlock:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("slow content"))
+		}
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.Timeout = 50 * time.Millisecond
+	config.BlockPrivateIPs = false
+
+	input := `<esi:try>
+	<esi:attempt>
+		<esi:include src="` + server.URL + `/slow"/>
+	</esi:attempt>
+	<esi:except>
+		timeout fallback
+	</esi:except>
+</esi:try>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "timeout fallback") {
+		t.Errorf("expected except content on timeout, got %q", result)
+	}
+	close(handlerBlock)
+}
+
+func TestESITryNoExcept(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("not found"))
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+
+	input := `<esi:try>
+	<esi:attempt>
+		<esi:include src="` + server.URL + `/missing"/>
+	</esi:attempt>
+</esi:try>`
+
+	result := MESIParse(input, config)
+	if result != "" {
+		t.Errorf("expected empty output when no except, got %q", result)
+	}
+}
+
+func TestESITryWithOnerrorContinue(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("error"))
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+
+	// onerror="continue" should NOT trigger except
+	input := `<esi:try>
+	<esi:attempt>
+		<esi:include onerror="continue" src="` + server.URL + `/fail"/>
+		after include
+	</esi:attempt>
+	<esi:except>
+		except content
+	</esi:except>
+</esi:try>`
+
+	result := MESIParse(input, config)
+	if strings.Contains(result, "except content") {
+		t.Errorf("onerror=continue should NOT trigger except, got %q", result)
+	}
+	if !strings.Contains(result, "after include") {
+		t.Errorf("content after include with onerror=continue should appear, got %q", result)
+	}
+}
+
+func TestESITryWithFallbackBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("error"))
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+
+	// fallback body should NOT trigger except
+	input := `<esi:try>
+	<esi:attempt>
+		<esi:include src="` + server.URL + `/fail">fallback body</esi:include>
+	</esi:attempt>
+	<esi:except>
+		except content
+	</esi:except>
+</esi:try>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "fallback body") {
+		t.Errorf("fallback body should be rendered, got %q", result)
+	}
+	if strings.Contains(result, "except content") {
+		t.Errorf("fallback body should NOT trigger except, got %q", result)
+	}
+}
+
+func TestESITryMultipleIncludesOneFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ok":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok content"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("not found"))
+		}
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+
+	// One failing include should trigger except for the entire try block
+	input := `<esi:try>
+	<esi:attempt>
+		<esi:include src="` + server.URL + `/ok"/>
+		<esi:include src="` + server.URL + `/missing"/>
+	</esi:attempt>
+	<esi:except>
+		except content
+	</esi:except>
+</esi:try>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "except content") {
+		t.Errorf("any failing include should trigger except, got %q", result)
+	}
+}
+
+func TestESITryNested(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/inner-ok":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("inner ok"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("error"))
+		}
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 2
+	config.BlockPrivateIPs = false
+
+	// Outer try should succeed because inner try catches the failure
+	input := `<esi:try>
+	<esi:attempt>
+		<esi:try>
+			<esi:attempt>
+				<esi:include src="` + server.URL + `/missing"/>
+			</esi:attempt>
+			<esi:except>
+				inner caught
+			</esi:except>
+		</esi:try>
+	</esi:attempt>
+	<esi:except>
+		outer except
+	</esi:except>
+</esi:try>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "inner caught") {
+		t.Errorf("inner try should render except, got %q", result)
+	}
+	if strings.Contains(result, "outer except") {
+		t.Errorf("outer try should NOT trigger except when inner catches, got %q", result)
+	}
+}
+
+func TestESITryNestedIncludeInsideAttempt(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("included data"))
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+
+	input := `<esi:try>
+	<esi:attempt>
+		before [<esi:include src="` + server.URL + `/fragment"/>] after
+	</esi:attempt>
+	<esi:except>
+		except content
+	</esi:except>
+</esi:try>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "included data") {
+		t.Errorf("include inside attempt should be processed, got %q", result)
+	}
+	if !strings.Contains(result, "before") || !strings.Contains(result, "after") {
+		t.Errorf("static text around include should be preserved, got %q", result)
+	}
+	if strings.Contains(result, "except content") {
+		t.Errorf("except should not be rendered on success, got %q", result)
+	}
+}
+
+func TestESITryEmptyAttempt(t *testing.T) {
+	config := CreateDefaultConfig()
+	config.MaxDepth = 1
+
+	input := `<esi:try>
+	<esi:attempt></esi:attempt>
+	<esi:except>fallback</esi:except>
+</esi:try>`
+
+	result := MESIParse(input, config)
+	if result != "" {
+		t.Errorf("empty attempt should produce empty output, got %q", result)
+	}
+}
+
+func TestESITryE2EFixture(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hello":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Hello World"))
+		case "/status/code/500":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(http.StatusText(http.StatusInternalServerError)))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(http.StatusText(http.StatusNotFound)))
+		}
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+
+	input := `<esi:try>
+	<esi:attempt>
+		before [<esi:include src="` + server.URL + `/hello"/>] after
+	</esi:attempt>
+	<esi:except>
+		except should not appear
+	</esi:except>
+</esi:try>
+---
+<esi:try>
+	<esi:attempt>
+		<esi:include src="` + server.URL + `/status/code/500"/>
+	</esi:attempt>
+	<esi:except>
+		fallback rendered
+	</esi:except>
+</esi:try>
+---
+<esi:try>
+	<esi:attempt>
+		<esi:include onerror="continue" src="` + server.URL + `/status/code/500"/>
+		after error
+	</esi:attempt>
+	<esi:except>
+		except should not appear
+	</esi:except>
+</esi:try>`
+
+	result := MESIParse(input, config)
+
+	if !strings.Contains(result, "before [Hello World] after") {
+		t.Errorf("first try: expected include content, got %q", result)
+	}
+	if !strings.Contains(result, "fallback rendered") {
+		t.Errorf("second try: expected except fallback, got %q", result)
+	}
+	if strings.Contains(result, "except should not appear") {
+		t.Errorf("except should not be rendered when not triggered")
+	}
+	if !strings.Contains(result, "after error") {
+		t.Errorf("third try: onerror=continue content should appear, got %q", result)
+	}
+}

--- a/mesi/tokenizer.go
+++ b/mesi/tokenizer.go
@@ -32,6 +32,36 @@ func (token *esiToken) isSupported() bool {
 	return token.isEsi() && token.esiTagType == ESI_INCLUDE
 }
 
+// findMatchingEndTag finds the position (relative to s) of closeTag that
+// matches the first openTag in s. Tracks nesting depth of <esi:*> tags so
+// that nested blocks with the same tag type don't confuse matching.
+func findMatchingEndTag(s string, openTag string, closeTag string) int {
+	depth := 0
+	pos := 0
+	for {
+		nextOpen := strings.Index(s[pos:], openTag)
+		nextClose := strings.Index(s[pos:], closeTag)
+		if nextClose == -1 {
+			return -1
+		}
+		if nextOpen != -1 && nextOpen < nextClose {
+			depth++
+			// Advance past the opening tag's '>' to avoid re-matching
+			tagEnd := strings.Index(s[pos+nextOpen:], ">")
+			if tagEnd == -1 {
+				return -1
+			}
+			pos += nextOpen + tagEnd + 1
+			continue
+		}
+		depth--
+		if depth == 0 {
+			return pos + nextClose
+		}
+		pos += nextClose + len(closeTag)
+	}
+}
+
 func esiTokenizer(input string) []esiToken {
 	var esiTokens []esiToken
 	unsupportedTags := []string{ESI_INLINE, ESI_CHOOSE, ESI_TRY, ESI_REMOVE, ESI_VARS, ESI_COMMENT, ESI_INCLUDE}
@@ -63,10 +93,17 @@ func esiTokenizer(input string) []esiToken {
 			endTag = "</esi:" + tag + ">"
 		}
 
-		end := strings.Index(input[start:], endTag)
-		if tag == "include" && end >= 0 && input[end+start-1] != '/' {
-			endTag = "</esi:" + tag + ">"
+		var end int
+		if tag == "try" || tag == "choose" || tag == "inline" || tag == "remove" || tag == "vars" {
+			// For block tags that can contain nested ESI blocks,
+			// find the matching closing tag using depth tracking.
+			end = findMatchingEndTag(input[start:], "<esi:"+tag, endTag)
+		} else {
 			end = strings.Index(input[start:], endTag)
+			if tag == "include" && end >= 0 && input[end+start-1] != '/' {
+				endTag = "</esi:" + tag + ">"
+				end = strings.Index(input[start:], endTag)
+			}
 		}
 
 		if end == -1 {

--- a/tests/fixtures/12-esi-try.html
+++ b/tests/fixtures/12-esi-try.html
@@ -1,0 +1,27 @@
+<esi:try>
+	<esi:attempt>
+		before [<esi:include src="http://127.0.0.1:8080/hello"/>] after
+	</esi:attempt>
+	<esi:except>
+		except should not appear
+	</esi:except>
+</esi:try>
+---
+<esi:try>
+	<esi:attempt>
+		<esi:include src="http://127.0.0.1:8080/status/code/500"/>
+	</esi:attempt>
+	<esi:except>
+		fallback rendered
+	</esi:except>
+</esi:try>
+---
+<esi:try>
+	<esi:attempt>
+		<esi:include onerror="continue" src="http://127.0.0.1:8080/status/code/500"/>
+		after error
+	</esi:attempt>
+	<esi:except>
+		except should not appear
+	</esi:except>
+</esi:try>

--- a/tests/fixtures/12-esi-try.html.expected
+++ b/tests/fixtures/12-esi-try.html.expected
@@ -1,0 +1,8 @@
+
+before [Hello World] after
+---
+fallback rendered
+---
+
+		after error
+	


### PR DESCRIPTION
Closes #163

## Summary

Implements graceful degradation for ESI includes via `<esi:try>` blocks. If any `<esi:include>` inside `<esi:attempt>` fails with an unhandled error (no `onerror='continue'`, no fallback body), the `<esi:except>` body is rendered instead.

## Changes

- **include.go**: `toString()` now returns `(string, bool, error)` to propagate unhandled include errors for try block detection
- **parser.go**: Added `processTryBlock`, `processAttemptContent`, `extractTryBlocks` and nesting-aware tag matchers (`findAttemptClose`, `findExceptClose`, `findTryClose`)
- **tokenizer.go**: Fixed nesting handling for block tags (`try`, `choose`, `inline`, `remove`, `vars`) — uses depth tracking to find matching closing tags instead of naive first-match
- **Unit tests**: 11 tests covering success, 404/timeout failure, no except, onerror=continue, fallback body, multiple includes (any fails → except), nested try, and e2e fixture scenario
- **docs/features.md**: `<esi:try>` marked as ✅ fully supported
- **debian/changelog**: Entry for 0.6.0