### PR TITLE
[core] Implement <esi:choose>, <esi:when>, <esi:otherwise> (#162)

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -9,7 +9,7 @@ Support status of mESI features across all server integrations.
 | `<esi:comment>` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `<!--esi ... -->` (inline) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `<esi:inline>` | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
-| `<esi:choose>`, `<esi:when>`, `<esi:otherwise>` | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
+| `<esi:choose>`, `<esi:when>`, `<esi:otherwise>` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `<esi:try>`, `<esi:attempt>`, `<esi:except>` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `<esi:vars>` / `$(...)` variable substitution | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `src` / `alt` attributes | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -51,7 +51,7 @@ Support status of mESI features across all server integrations.
 ## Notes
 
 - **`<esi:inline>`** – Recognized by the tokenizer (no parse errors), but content is silently dropped from output. Full support planned.
-- **`<esi:choose>`, `<esi:when>`, `<esi:otherwise>`** – Recognized by the tokenizer (no parse errors), but content is silently dropped from output. Full support planned.
+- **`<esi:choose>`, `<esi:when>`, `<esi:otherwise>`** – Fully supported. Boolean `test` attributes (`true`/`false`/`0`/`1`) select the first matching `<esi:when>` branch. If no branch matches, `<esi:otherwise>` is rendered (if present). `$(...)` variables in `test` are resolved before evaluation. Supports nested `<esi:choose>`, `<esi:include>`, `<esi:try>`, and `<esi:vars>` inside branch bodies.
 - **`<esi:try>`, `<esi:attempt>`, `<esi:except>`** – Fully supported. Unhandled include errors within `<esi:attempt>` trigger `<esi:except>` rendering. `onerror="continue"` and fallback body do NOT trigger `<esi:except>`. Supports nested `<esi:try>` blocks.
 - **`<esi:vars>` / `$(...)` variable substitution** – Fully supported. Variables are defined via `<esi:variable>` in `<esi:vars>` blocks and resolved via `$(NAME)` syntax in include URLs, text content, and test expressions. Supports `$(HTTP_HEADER{Name})`, `$(HTTP_COOKIE{name})`, and `$(QUERY_STRING{param})` via config fields.
 - **Nginx** – Uses the `Parse` function from `libgomesi` which does not enable `BlockPrivateIPs` (defaults to `false`). No SSRF protection.

--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -100,6 +100,9 @@ func MESIParse(input string, config EsiParserConfig) string {
 		} else if token.esiTagType == ESI_TRY {
 			content := processTryBlock(token.esiTagContent, config, start)
 			results = append(results, Response{content, index})
+		} else if token.esiTagType == ESI_CHOOSE {
+			content := processChooseBlock(token.esiTagContent, config)
+			results = append(results, Response{content, index})
 		} else if !token.isEsi() {
 			content := evaluateExpression(token.staticContent, config)
 			results = append(results, Response{content, index})
@@ -395,6 +398,310 @@ func findTryClose(s string) int {
 	}
 }
 
+// evaluateTest evaluates a boolean test expression from an <esi:when test="...">
+// attribute. Supports boolean literals: "true", "false", "", "0", "1".
+// $(...) variables in the expression are resolved before evaluation.
+// Full expression syntax (comparisons, boolean operators) can be added later.
+func evaluateTest(expr string, config EsiParserConfig) bool {
+	expr = evaluateExpression(strings.TrimSpace(expr), config)
+	switch expr {
+	case "true", "1":
+		return true
+	case "false", "0", "":
+		return false
+	}
+	return false
+}
+
+// esiWhenBlock represents a single <esi:when test="...">...</esi:when> block.
+type esiWhenBlock struct {
+	Test string
+	Body string
+}
+
+// extractChooseBlocks parses the raw content of an <esi:choose> token and
+// extracts the list of <esi:when> blocks and optional <esi:otherwise> body.
+// Properly handles nested <esi:choose> blocks by tracking nesting depth.
+func extractChooseBlocks(raw string) (whens []esiWhenBlock, otherwise string) {
+	closeBracket := strings.Index(raw, ">")
+	if closeBracket == -1 {
+		return nil, ""
+	}
+	pos := closeBracket + 1
+
+	for {
+		// Find next potential child tag
+		nextWhen := findChooseChildTag(raw[pos:], "<esi:when")
+		nextOtherwise := findChooseChildTag(raw[pos:], "<esi:otherwise")
+		nextClose := findChooseChildTag(raw[pos:], "</esi:choose>")
+
+		// If no more children, stop
+		if nextWhen == -1 && nextOtherwise == -1 {
+			break
+		}
+
+		// Check if we hit </esi:choose> first
+		if nextClose != -1 && (nextWhen == -1 || nextClose < nextWhen) && (nextOtherwise == -1 || nextClose < nextOtherwise) {
+			break
+		}
+
+		if nextWhen != -1 && (nextOtherwise == -1 || nextWhen < nextOtherwise) {
+			// Process <esi:when test="...">
+			tagStart := pos + nextWhen
+
+			// Extract test attribute
+			testStart := strings.Index(raw[tagStart:], "test=\"")
+			if testStart == -1 {
+				// Malformed, skip
+				quoteEnd := strings.Index(raw[tagStart:], ">")
+				if quoteEnd == -1 {
+					break
+				}
+				pos = tagStart + quoteEnd + 1
+				continue
+			}
+			testStart += tagStart + len("test=\"")
+			testEnd := strings.Index(raw[testStart:], "\"")
+			if testEnd == -1 {
+				break
+			}
+			testExpr := raw[testStart : testStart+testEnd]
+
+			// Find end of opening <esi:when ...> tag
+			bodyStart := testStart + testEnd
+			tagEnd := strings.Index(raw[bodyStart:], ">")
+			if tagEnd == -1 {
+				break
+			}
+			bodyStart += tagEnd + 1
+
+			// Find matching </esi:when> (depth-aware for nested <esi:choose>)
+			whenBodyLen := findWhenClose(raw[bodyStart:])
+			if whenBodyLen == -1 {
+				// No matching close tag, consume rest and stop
+				whenBody := raw[bodyStart:]
+				whens = append(whens, esiWhenBlock{Test: testExpr, Body: whenBody})
+				pos = len(raw)
+				break
+			}
+			whenBody := raw[bodyStart : bodyStart+whenBodyLen]
+
+			whens = append(whens, esiWhenBlock{Test: testExpr, Body: whenBody})
+			pos = bodyStart + whenBodyLen + len("</esi:when>")
+		} else if nextOtherwise != -1 {
+			// Process <esi:otherwise>
+			tagStart := pos + nextOtherwise
+
+			// Find end of opening <esi:otherwise ...> tag
+			tagEnd := strings.Index(raw[tagStart:], ">")
+			if tagEnd == -1 {
+				break
+			}
+			bodyStart := tagStart + tagEnd + 1
+
+			// Find matching </esi:otherwise> (depth-aware)
+			otherwiseLen := findOtherwiseClose(raw[bodyStart:])
+			if otherwiseLen == -1 {
+				// No matching close tag, consume rest and stop
+				otherwise = raw[bodyStart:]
+				pos = len(raw)
+				break
+			}
+			otherwise = raw[bodyStart : bodyStart+otherwiseLen]
+			pos = bodyStart + otherwiseLen + len("</esi:otherwise>")
+		} else {
+			break
+		}
+	}
+
+	return whens, otherwise
+}
+
+// findChooseChildTag finds the first occurrence of tag in s that is a direct
+// child (skipping nested <esi:choose> blocks).
+func findChooseChildTag(s string, tag string) int {
+	pos := 0
+	for {
+		nextNested := strings.Index(s[pos:], "<esi:choose")
+		nextTarget := strings.Index(s[pos:], tag)
+		if nextTarget == -1 {
+			return -1
+		}
+		if nextNested != -1 && nextNested < nextTarget {
+			// Skip this nested <esi:choose> block
+			nestedClose := findChooseClose(s[pos+nextNested:])
+			if nestedClose == -1 {
+				return -1
+			}
+			pos += nextNested + nestedClose
+			continue
+		}
+		return pos + nextTarget
+	}
+}
+
+// findChooseClose finds the position (relative to s) of the </esi:choose>
+// that matches the first <esi:choose> in s. s starts at the opening
+// <esi:choose tag.
+func findChooseClose(s string) int {
+	depth := 0
+	pos := 0
+	for {
+		nextClose := strings.Index(s[pos:], "</esi:choose>")
+		if nextClose == -1 {
+			return -1
+		}
+		nextOpen := strings.Index(s[pos:], "<esi:choose")
+		if nextOpen != -1 && nextOpen < nextClose {
+			depth++
+			nextEnd := strings.Index(s[pos+nextOpen:], ">")
+			if nextEnd == -1 {
+				return -1
+			}
+			pos += nextOpen + nextEnd + 1
+			continue
+		}
+		if depth == 0 {
+			return pos + nextClose + len("</esi:choose>")
+		}
+		depth--
+		pos += nextClose + len("</esi:choose>")
+	}
+}
+
+// findWhenClose finds the position (relative to s) of the </esi:when>
+// that matches the first <esi:when> in s. s starts after the opening
+// <esi:when ...> tag. Handles nested <esi:choose> blocks.
+func findWhenClose(s string) int {
+	depth := 0
+	pos := 0
+	for {
+		nextClose := strings.Index(s[pos:], "</esi:when>")
+		nextCloseChoose := strings.Index(s[pos:], "</esi:choose>")
+		firstClose := -1
+		if nextClose != -1 && (nextCloseChoose == -1 || nextClose < nextCloseChoose) {
+			firstClose = nextClose
+		} else if nextCloseChoose != -1 {
+			firstClose = nextCloseChoose
+		} else if nextClose != -1 {
+			firstClose = nextClose
+		}
+		if firstClose == -1 {
+			return -1
+		}
+		nextOpenWhen := strings.Index(s[pos:], "<esi:when")
+		nextOpenChoose := strings.Index(s[pos:], "<esi:choose")
+		firstOpen := -1
+		if nextOpenWhen != -1 && (nextOpenChoose == -1 || nextOpenWhen < nextOpenChoose) {
+			firstOpen = nextOpenWhen
+		} else if nextOpenChoose != -1 {
+			firstOpen = nextOpenChoose
+		} else if nextOpenWhen != -1 {
+			firstOpen = nextOpenWhen
+		}
+		if firstOpen != -1 && firstOpen < firstClose {
+			depth++
+			nextEnd := strings.Index(s[pos+firstOpen:], ">")
+			if nextEnd == -1 {
+				return -1
+			}
+			pos += firstOpen + nextEnd + 1
+			continue
+		}
+		if depth == 0 && firstClose == nextClose {
+			return pos + nextClose
+		}
+		depth--
+		var skipLen int
+		if firstClose == nextClose {
+			skipLen = len("</esi:when>")
+		} else {
+			skipLen = len("</esi:choose>")
+		}
+		pos += firstClose + skipLen
+	}
+}
+
+// findOtherwiseClose finds the position (relative to s) of the </esi:otherwise>
+// that matches the first <esi:otherwise> in s. s starts after the opening
+// <esi:otherwise ...> tag. Handles nested blocks.
+func findOtherwiseClose(s string) int {
+	depth := 0
+	pos := 0
+	for {
+		nextClose := strings.Index(s[pos:], "</esi:otherwise>")
+		nextCloseChoose := strings.Index(s[pos:], "</esi:choose>")
+		firstClose := -1
+		if nextClose != -1 && (nextCloseChoose == -1 || nextClose < nextCloseChoose) {
+			firstClose = nextClose
+		} else if nextCloseChoose != -1 {
+			firstClose = nextCloseChoose
+		} else if nextClose != -1 {
+			firstClose = nextClose
+		}
+		if firstClose == -1 {
+			return -1
+		}
+		nextOpenOtherwise := strings.Index(s[pos:], "<esi:otherwise")
+		nextOpenChoose := strings.Index(s[pos:], "<esi:choose")
+		firstOpen := -1
+		if nextOpenOtherwise != -1 && (nextOpenChoose == -1 || nextOpenOtherwise < nextOpenChoose) {
+			firstOpen = nextOpenOtherwise
+		} else if nextOpenChoose != -1 {
+			firstOpen = nextOpenChoose
+		} else if nextOpenOtherwise != -1 {
+			firstOpen = nextOpenOtherwise
+		}
+		if firstOpen != -1 && firstOpen < firstClose {
+			depth++
+			nextEnd := strings.Index(s[pos+firstOpen:], ">")
+			if nextEnd == -1 {
+				return -1
+			}
+			pos += firstOpen + nextEnd + 1
+			continue
+		}
+		if depth == 0 && firstClose == nextClose {
+			return pos + nextClose
+		}
+		depth--
+		var skipLen int
+		if firstClose == nextClose {
+			skipLen = len("</esi:otherwise>")
+		} else {
+			skipLen = len("</esi:choose>")
+		}
+		pos += firstClose + skipLen
+	}
+}
+
+// processChooseBlock processes an <esi:choose> block. It evaluates each
+// <esi:when test="..."> condition in order and renders the body of the first
+// matching branch. If no <esi:when> matches and an <esi:otherwise> exists,
+// it renders the otherwise body. The selected body is recursively parsed
+// for further ESI processing (nested includes, vars, etc.).
+func processChooseBlock(raw string, config EsiParserConfig) string {
+	logger := config.getLogger()
+	whens, otherwise := extractChooseBlocks(raw)
+
+	logger.Debug("choose_start", "when_count", len(whens), "has_otherwise", otherwise != "")
+
+	for _, w := range whens {
+		if evaluateTest(w.Test, config) {
+			logger.Debug("choose_when_matched", "test", w.Test)
+			return MESIParse(w.Body, config)
+		}
+	}
+
+	if otherwise != "" {
+		logger.Debug("choose_no_match_rendering_otherwise")
+		return MESIParse(otherwise, config)
+	}
+
+	logger.Debug("choose_no_match_no_otherwise")
+	return ""
+}
+
 // processTryBlock handles a <esi:try> block. It processes the attempt body
 // with error tracking. If any include inside attempt fails with an unhandled
 // error (no onerror="continue" and no fallback body), the except body is
@@ -455,6 +762,9 @@ func processAttemptContent(content string, config EsiParserConfig, start time.Ti
 			results = append(results, Response{data, index})
 		} else if token.esiTagType == ESI_TRY {
 			data := processTryBlock(token.esiTagContent, config, start)
+			results = append(results, Response{data, index})
+		} else if token.esiTagType == ESI_CHOOSE {
+			data := processChooseBlock(token.esiTagContent, config)
 			results = append(results, Response{data, index})
 		} else if !token.isEsi() {
 			content := evaluateExpression(token.staticContent, config)

--- a/mesi/parser.go
+++ b/mesi/parser.go
@@ -481,7 +481,6 @@ func extractChooseBlocks(raw string) (whens []esiWhenBlock, otherwise string) {
 				// No matching close tag, consume rest and stop
 				whenBody := raw[bodyStart:]
 				whens = append(whens, esiWhenBlock{Test: testExpr, Body: whenBody})
-				pos = len(raw)
 				break
 			}
 			whenBody := raw[bodyStart : bodyStart+whenBodyLen]
@@ -504,7 +503,6 @@ func extractChooseBlocks(raw string) (whens []esiWhenBlock, otherwise string) {
 			if otherwiseLen == -1 {
 				// No matching close tag, consume rest and stop
 				otherwise = raw[bodyStart:]
-				pos = len(raw)
 				break
 			}
 			otherwise = raw[bodyStart : bodyStart+otherwiseLen]

--- a/mesi/parser_test.go
+++ b/mesi/parser_test.go
@@ -861,6 +861,543 @@ func TestESITryEmptyAttempt(t *testing.T) {
 	}
 }
 
+func TestExtractChooseBlocks(t *testing.T) {
+	tests := []struct {
+		name            string
+		input           string
+		wantWhenCount   int
+		wantWhenTests   []string
+		wantWhenBodies  []string
+		wantOtherwise   string
+	}{
+		{
+			name:          "single when true",
+			input:         `<esi:choose><esi:when test="true">body</esi:when></esi:choose>`,
+			wantWhenCount: 1,
+			wantWhenTests: []string{"true"},
+			wantWhenBodies: []string{"body"},
+			wantOtherwise: "",
+		},
+		{
+			name:          "multiple whens with otherwise",
+			input:         `<esi:choose><esi:when test="true">a</esi:when><esi:when test="false">b</esi:when><esi:otherwise>c</esi:otherwise></esi:choose>`,
+			wantWhenCount: 2,
+			wantWhenTests: []string{"true", "false"},
+			wantWhenBodies: []string{"a", "b"},
+			wantOtherwise: "c",
+		},
+		{
+			name:          "otherwise only",
+			input:         `<esi:choose><esi:otherwise>fallback</esi:otherwise></esi:choose>`,
+			wantWhenCount: 0,
+			wantOtherwise: "fallback",
+		},
+		{
+			name:          "no whens, no otherwise",
+			input:         `<esi:choose></esi:choose>`,
+			wantWhenCount: 0,
+			wantOtherwise: "",
+		},
+		{
+			name:          "when with nested choose inside",
+			input:         `<esi:choose><esi:when test="true"><esi:choose><esi:when test="false">nested</esi:when></esi:choose></esi:when></esi:choose>`,
+			wantWhenCount: 1,
+			wantWhenTests: []string{"true"},
+			wantWhenBodies: []string{"<esi:choose><esi:when test=\"false\">nested</esi:when></esi:choose>"},
+			wantOtherwise: "",
+		},
+		{
+			name:          "when with include inside",
+			input:         `<esi:choose><esi:when test="true"><esi:include src="/fragment"/></esi:when><esi:otherwise>fallback</esi:otherwise></esi:choose>`,
+			wantWhenCount: 1,
+			wantWhenTests: []string{"true"},
+			wantWhenBodies: []string{"<esi:include src=\"/fragment\"/>"},
+			wantOtherwise: "fallback",
+		},
+		{
+			name:          "test attribute with extra whitespace",
+			input:         `<esi:choose><esi:when test=" true ">body</esi:when></esi:choose>`,
+			wantWhenCount: 1,
+			wantWhenTests: []string{" true "},
+			wantWhenBodies: []string{"body"},
+			wantOtherwise: "",
+		},
+		{
+			name:          "choose with body content before when (should be ignored)",
+			input:         `<esi:choose>ignored text<esi:when test="true">body</esi:when></esi:choose>`,
+			wantWhenCount: 1,
+			wantWhenTests: []string{"true"},
+			wantWhenBodies: []string{"body"},
+			wantOtherwise: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			whens, otherwise := extractChooseBlocks(tt.input)
+			if len(whens) != tt.wantWhenCount {
+				t.Errorf("whens = %d, want %d", len(whens), tt.wantWhenCount)
+			}
+			if otherwise != tt.wantOtherwise {
+				t.Errorf("otherwise = %q, want %q", otherwise, tt.wantOtherwise)
+			}
+			for i, w := range whens {
+				if i >= len(tt.wantWhenTests) {
+					break
+				}
+				if w.Test != tt.wantWhenTests[i] {
+					t.Errorf("whens[%d].Test = %q, want %q", i, w.Test, tt.wantWhenTests[i])
+				}
+				if w.Body != tt.wantWhenBodies[i] {
+					t.Errorf("whens[%d].Body = %q, want %q", i, w.Body, tt.wantWhenBodies[i])
+				}
+			}
+		})
+	}
+}
+
+func TestEvaluateTest(t *testing.T) {
+	config := CreateDefaultConfig()
+	tests := []struct {
+		name   string
+		expr   string
+		expect bool
+	}{
+		{"true literal", "true", true},
+		{"TRUE uppercase", "TRUE", false},
+		{"false literal", "false", false},
+		{"1 is true", "1", true},
+		{"0 is false", "0", false},
+		{"empty string is false", "", false},
+		{"whitespace is false", "  ", false},
+		{"random string is false", "some expression", false},
+		{"true with spaces", "  true  ", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := evaluateTest(tt.expr, config)
+			if result != tt.expect {
+				t.Errorf("evaluateTest(%q) = %v, want %v", tt.expr, result, tt.expect)
+			}
+		})
+	}
+}
+
+func TestEvaluateTestWithVariables(t *testing.T) {
+	config := CreateDefaultConfig()
+	config.Variables = map[string]string{"FLAG": "true", "DISABLED": "false"}
+
+	tests := []struct {
+		name   string
+		expr   string
+		expect bool
+	}{
+		{"$(FLAG) resolves to true", "$(FLAG)", true},
+		{"$(DISABLED) resolves to false", "$(DISABLED)", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := evaluateTest(tt.expr, config)
+			if result != tt.expect {
+				t.Errorf("evaluateTest(%q) = %v, want %v", tt.expr, result, tt.expect)
+			}
+		})
+	}
+}
+
+func TestChooseTrueRendersWhenBody(t *testing.T) {
+	config := CreateDefaultConfig()
+	config.MaxDepth = 0
+
+	input := `<esi:choose>
+	<esi:when test="true">WHEN_BODY</esi:when>
+	<esi:otherwise>OTHERWISE</esi:otherwise>
+</esi:choose>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "WHEN_BODY") {
+		t.Errorf("expected WHEN_BODY in result, got %q", result)
+	}
+	if strings.Contains(result, "OTHERWISE") {
+		t.Errorf("otherwise should NOT be rendered when when matches, got %q", result)
+	}
+}
+
+func TestChooseFalseRendersOtherwise(t *testing.T) {
+	config := CreateDefaultConfig()
+	config.MaxDepth = 0
+
+	input := `<esi:choose>
+	<esi:when test="false">WHEN_BODY</esi:when>
+	<esi:otherwise>OTHERWISE_BODY</esi:otherwise>
+</esi:choose>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "OTHERWISE_BODY") {
+		t.Errorf("expected OTHERWISE_BODY in result, got %q", result)
+	}
+	if strings.Contains(result, "WHEN_BODY") {
+		t.Errorf("when body should NOT be rendered when test=false, got %q", result)
+	}
+}
+
+func TestChooseAllFalseNoOtherwiseEmpty(t *testing.T) {
+	config := CreateDefaultConfig()
+	config.MaxDepth = 0
+
+	input := `<esi:choose>
+	<esi:when test="false">FIRST</esi:when>
+	<esi:when test="0">SECOND</esi:when>
+</esi:choose>`
+
+	result := MESIParse(input, config)
+	if result != "" {
+		t.Errorf("expected empty output, got %q", result)
+	}
+}
+
+func TestChooseFirstMatchWinsShortCircuit(t *testing.T) {
+	config := CreateDefaultConfig()
+	config.MaxDepth = 0
+
+	input := `<esi:choose>
+	<esi:when test="true">FIRST_MATCH</esi:when>
+	<esi:when test="true">SECOND_MATCH</esi:when>
+	<esi:otherwise>OTHERWISE</esi:otherwise>
+</esi:choose>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "FIRST_MATCH") {
+		t.Errorf("expected FIRST_MATCH in result, got %q", result)
+	}
+	if strings.Contains(result, "SECOND_MATCH") {
+		t.Errorf("second when should NOT be rendered (short-circuit), got %q", result)
+	}
+	if strings.Contains(result, "OTHERWISE") {
+		t.Errorf("otherwise should NOT be rendered when when matches, got %q", result)
+	}
+}
+
+func TestChooseNestedIncludeInsideWhenIsProcessed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("INCLUDED_CONTENT"))
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+
+	input := `<esi:choose>
+	<esi:when test="true">
+		before [<esi:include src="` + server.URL + `/fragment"/>] after
+	</esi:when>
+	<esi:otherwise>fallback</esi:otherwise>
+</esi:choose>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "INCLUDED_CONTENT") {
+		t.Errorf("include inside when should be processed, got %q", result)
+	}
+	if !strings.Contains(result, "before") || !strings.Contains(result, "after") {
+		t.Errorf("static text around include should be preserved, got %q", result)
+	}
+	if strings.Contains(result, "fallback") {
+		t.Errorf("otherwise should not be rendered, got %q", result)
+	}
+}
+
+func TestChooseEmptyTestAttributeIsFalse(t *testing.T) {
+	config := CreateDefaultConfig()
+	config.MaxDepth = 0
+
+	input := `<esi:choose>
+	<esi:when test="">WHEN_BODY</esi:when>
+	<esi:otherwise>OTHERWISE_BODY</esi:otherwise>
+</esi:choose>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "OTHERWISE_BODY") {
+		t.Errorf("expected OTHERWISE_BODY when test is empty, got %q", result)
+	}
+}
+
+func TestChooseMalformedWhenWithoutCloseTag(t *testing.T) {
+	config := CreateDefaultConfig()
+	config.MaxDepth = 0
+
+	// Missing </esi:when> inside properly-closed <esi:choose>
+	// The tokenizer produces an ESI_CHOOSE token; we should not panic.
+	input := `<esi:choose><esi:when test="true">body</esi:choose>`
+
+	result := MESIParse(input, config)
+	_ = result
+}
+
+func TestChooseMalformedOtherwiseWithoutCloseTag(t *testing.T) {
+	config := CreateDefaultConfig()
+	config.MaxDepth = 0
+
+	// Missing </esi:otherwise> inside properly-closed <esi:choose>
+	input := `<esi:choose><esi:when test="false">when</esi:when><esi:otherwise>body</esi:choose>`
+
+	result := MESIParse(input, config)
+	_ = result
+}
+
+func TestChooseMalformedMissingCloseTag(t *testing.T) {
+	config := CreateDefaultConfig()
+	config.MaxDepth = 0
+
+	// Missing </esi:choose> should not crash
+	input := `<esi:choose>
+	<esi:when test="true">body
+	<esi:otherwise>fallback`
+
+	result := MESIParse(input, config)
+	_ = result
+}
+
+func TestChooseMultipleBlocks(t *testing.T) {
+	config := CreateDefaultConfig()
+	config.MaxDepth = 0
+
+	input := `<esi:choose>
+	<esi:when test="true">FIRST</esi:when>
+</esi:choose>
+---
+<esi:choose>
+	<esi:when test="false">NOT_RENDERED</esi:when>
+	<esi:otherwise>SECOND</esi:otherwise>
+</esi:choose>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "FIRST") {
+		t.Errorf("expected FIRST in result, got %q", result)
+	}
+	if !strings.Contains(result, "SECOND") {
+		t.Errorf("expected SECOND in result, got %q", result)
+	}
+	if strings.Contains(result, "NOT_RENDERED") {
+		t.Errorf("NOT_RENDERED should not appear, got %q", result)
+	}
+}
+
+func TestChooseRepeatedInDocument(t *testing.T) {
+	config := CreateDefaultConfig()
+	config.MaxDepth = 0
+
+	input := `<esi:choose>
+	<esi:when test="true">A</esi:when>
+	<esi:otherwise>B</esi:otherwise>
+</esi:choose>
+<esi:choose>
+	<esi:when test="true">C</esi:when>
+	<esi:otherwise>D</esi:otherwise>
+</esi:choose>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "A") {
+		t.Errorf("expected A in result, got %q", result)
+	}
+	if !strings.Contains(result, "C") {
+		t.Errorf("expected C in result, got %q", result)
+	}
+}
+
+func TestESITryAndChooseE2EFixture(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/variant-a":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Variant A Content"))
+		case "/variant-b":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Variant B Content"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("Not Found"))
+		}
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+
+	// Test 1: choose + try combination
+	input := `<esi:choose>
+	<esi:when test="true">
+		<esi:try>
+			<esi:attempt>
+				<esi:include src="` + server.URL + `/variant-a"/>
+			</esi:attempt>
+			<esi:except>
+				fallback
+			</esi:except>
+		</esi:try>
+	</esi:when>
+	<esi:otherwise>
+		<esi:include src="` + server.URL + `/variant-b"/>
+	</esi:otherwise>
+</esi:choose>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "Variant A Content") {
+		t.Errorf("expected Variant A Content, got %q", result)
+	}
+	if strings.Contains(result, "Variant B Content") {
+		t.Errorf("Variant B should not appear")
+	}
+	if strings.Contains(result, "fallback") {
+		t.Errorf("fallback should not appear")
+	}
+}
+
+func TestESITryChooseNestedInAttempt(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("INCLUDED"))
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+
+	// choose inside try/attempt
+	input := `<esi:try>
+	<esi:attempt>
+		before
+		<esi:choose>
+			<esi:when test="true">
+				<esi:include src="` + server.URL + `/fragment"/>
+			</esi:when>
+			<esi:otherwise>otherwise body</esi:otherwise>
+		</esi:choose>
+		after
+	</esi:attempt>
+	<esi:except>
+		except body
+	</esi:except>
+</esi:try>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "INCLUDED") {
+		t.Errorf("expected INCLUDED from choose inside attempt, got %q", result)
+	}
+	if !strings.Contains(result, "before") || !strings.Contains(result, "after") {
+		t.Errorf("static text around choose should be preserved, got %q", result)
+	}
+	if strings.Contains(result, "otherwise body") {
+		t.Errorf("otherwise should not be rendered when when matches")
+	}
+	if strings.Contains(result, "except body") {
+		t.Errorf("except should not be rendered on success")
+	}
+}
+
+func TestESITryChooseNestedInExcept(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+
+	// choose inside try/except
+	input := `<esi:try>
+	<esi:attempt>
+		<esi:include src="` + server.URL + `/missing"/>
+	</esi:attempt>
+	<esi:except>
+		<esi:choose>
+			<esi:when test="true">except when body</esi:when>
+			<esi:otherwise>except otherwise</esi:otherwise>
+		</esi:choose>
+	</esi:except>
+</esi:try>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "except when body") {
+		t.Errorf("expected except when body, got %q", result)
+	}
+}
+
+func TestESITryChooseNestedNestedChoose(t *testing.T) {
+	config := CreateDefaultConfig()
+	config.MaxDepth = 0
+
+	// Nested choose blocks
+	input := `<esi:choose>
+	<esi:when test="true">
+		outer true:
+		<esi:choose>
+			<esi:when test="false">inner false</esi:when>
+			<esi:otherwise>inner otherwise</esi:otherwise>
+		</esi:choose>
+	</esi:when>
+	<esi:otherwise>
+		outer otherwise
+	</esi:otherwise>
+</esi:choose>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "outer true") {
+		t.Errorf("expected outer true text, got %q", result)
+	}
+	if !strings.Contains(result, "inner otherwise") {
+		t.Errorf("expected inner otherwise, got %q", result)
+	}
+	if strings.Contains(result, "inner false") {
+		t.Errorf("inner false should not be rendered")
+	}
+	if strings.Contains(result, "outer otherwise") {
+		t.Errorf("outer otherwise should not be rendered")
+	}
+}
+
+func TestESITryChooseWithVarsInTest(t *testing.T) {
+	config := CreateDefaultConfig()
+	config.MaxDepth = 0
+	config.Variables = map[string]string{"FEATURE_ENABLED": "true"}
+
+	input := `<esi:choose>
+	<esi:when test="$(FEATURE_ENABLED)">feature is on</esi:when>
+	<esi:otherwise>feature is off</esi:otherwise>
+</esi:choose>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "feature is on") {
+		t.Errorf("expected 'feature is on', got %q", result)
+	}
+}
+
+func TestESITryChooseWithVarsInTestFalse(t *testing.T) {
+	config := CreateDefaultConfig()
+	config.MaxDepth = 0
+	config.Variables = map[string]string{"FEATURE_ENABLED": "false"}
+
+	input := `<esi:choose>
+	<esi:when test="$(FEATURE_ENABLED)">feature is on</esi:when>
+	<esi:otherwise>feature is off</esi:otherwise>
+</esi:choose>`
+
+	result := MESIParse(input, config)
+	if !strings.Contains(result, "feature is off") {
+		t.Errorf("expected 'feature is off', got %q", result)
+	}
+}
+
 func TestESITryE2EFixture(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -925,3 +1462,5 @@ func TestESITryE2EFixture(t *testing.T) {
 		t.Errorf("third try: onerror=continue content should appear, got %q", result)
 	}
 }
+
+

--- a/tests/fixtures/13-esi-choose.html
+++ b/tests/fixtures/13-esi-choose.html
@@ -1,0 +1,27 @@
+<esi:choose>
+	<esi:when test="true">
+		before [<esi:include src="http://127.0.0.1:8080/hello"/>] after
+	</esi:when>
+	<esi:otherwise>
+		otherwise should not appear
+	</esi:otherwise>
+</esi:choose>
+---
+<esi:choose>
+	<esi:when test="false">
+		when should not appear
+	</esi:when>
+	<esi:otherwise>
+		fallback rendered
+	</esi:otherwise>
+</esi:choose>
+---
+<esi:choose>
+	<esi:when test="true">first match</esi:when>
+	<esi:when test="true">second should not appear</esi:when>
+	<esi:otherwise>otherwise should not appear</esi:otherwise>
+</esi:choose>
+---
+<esi:choose>
+	<esi:when test="false">no match</esi:when>
+</esi:choose>

--- a/tests/fixtures/13-esi-choose.html.expected
+++ b/tests/fixtures/13-esi-choose.html.expected
@@ -1,0 +1,8 @@
+
+		before [Hello World] after
+	
+---
+fallback rendered
+---
+first match
+---


### PR DESCRIPTION
## Summary

Implements conditional content selection via `<esi:choose>`, `<esi:when>`, and `<esi:otherwise>` elements in the core ESI parser.

Closes #162

## Changes

- **mesi/parser.go**: Added `evaluateTest()`, `extractChooseBlocks()`, `processChooseBlock()`, and depth-aware helper functions for parsing nested choose/when/otherwise blocks
- **mesi/parser_test.go**: 20+ unit tests covering all acceptance criteria
- **docs/features.md**: Updated feature matrix (⚠️ → ✅) and notes
- **tests/fixtures/**: Added e2e fixture (13-esi-choose)

## Implementation details

- Boolean literal `test` expressions (`true`/`false`/`0`/`1`)
- `$(...)` variable resolution in `test` attributes
- Depth-aware block extraction (handles nested `<esi:choose>`)
- Supports nesting inside `<esi:try>` (both attempt and except blocks)
- Short-circuit evaluation (first matching when wins)
- Graceful degradation for malformed input

## Test coverage

- `test="true"` → renders when body
- `test="false"` → renders otherwise
- All false, no otherwise → empty output
- First match wins (short-circuit)
- Nested include inside when is processed
- Empty test → false
- Malformed (missing close tags) → no panic
- `$(VAR)` resolution in test
- Multiple choose blocks in document
- Nested choose blocks
- Choose inside try/attempt and try/except