### PR TITLE
fix(mesi): add build tags to cache backends to fix Traefik Plugin Catalog

### DIFF
--- a/mesi/cache_build_tags_test.go
+++ b/mesi/cache_build_tags_test.go
@@ -1,0 +1,46 @@
+package mesi
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCacheBackendsAreBuildTagProtected(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+
+	files := []struct {
+		file string
+		tag  string
+	}{
+		{"cache_memcached.go", "memcached"},
+		{"cache_redis.go", "redis"},
+		{"cache_memcached_test.go", "memcached"},
+		{"cache_redis_test.go", "redis"},
+	}
+
+	for _, f := range files {
+		data, err := os.ReadFile(filepath.Join(wd, f.file))
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", f.file, err)
+		}
+		if !strings.Contains(string(data), "//go:build "+f.tag) {
+			t.Errorf("%s is missing build tag '//go:build %s'", f.file, f.tag)
+		}
+	}
+}
+
+func TestMemoryCacheAvailableWithoutBuildTags(t *testing.T) {
+	cache := NewMemoryCache(100, 0)
+	if cache == nil {
+		t.Fatal("NewMemoryCache returned nil")
+	}
+}
+
+func TestCacheInterfaceSatisfied(t *testing.T) {
+	var _ Cache = (*MemoryCache)(nil)
+}

--- a/mesi/cache_memcached.go
+++ b/mesi/cache_memcached.go
@@ -1,3 +1,5 @@
+//go:build memcached
+
 package mesi
 
 import (

--- a/mesi/cache_memcached_test.go
+++ b/mesi/cache_memcached_test.go
@@ -1,3 +1,5 @@
+//go:build memcached
+
 package mesi
 
 import (

--- a/mesi/cache_redis.go
+++ b/mesi/cache_redis.go
@@ -1,3 +1,5 @@
+//go:build redis
+
 package mesi
 
 import (

--- a/mesi/cache_redis_test.go
+++ b/mesi/cache_redis_test.go
@@ -1,3 +1,5 @@
+//go:build redis
+
 package mesi
 
 import (

--- a/servers/caddy/Makefile
+++ b/servers/caddy/Makefile
@@ -1,5 +1,5 @@
 build:
-	xcaddy build --with github.com/crazy-goat/go-mesi/servers/caddy=.
+	xcaddy build --tags "memcached redis" --with github.com/crazy-goat/go-mesi/servers/caddy=.
 
 run: build
 	./caddy run --config Caddyfile

--- a/servers/caddy/mesi_integration_test.go
+++ b/servers/caddy/mesi_integration_test.go
@@ -1,3 +1,5 @@
+//go:build memcached || redis
+
 package caddy
 
 import (


### PR DESCRIPTION
## Problem

The Traefik Plugin Catalog analyzer (Yaegi) fails to load the plugin because it cannot resolve  and  dependencies that are pulled in transitively through the  package.

Error from Traefik Plugin Catalog:


Fixes #273

## Solution

Add build tags to cache backend files so they are only compiled when explicitly requested:

-  for  and 
-  for  and 
-  for 
- Updated  to pass build tags

This allows the Traefik plugin to compile without external cache dependencies while maintaining full functionality for integrations that need them (caddy, etc.).