### PR TITLE
feat(caddy): add include_error_marker Caddyfile directive

### DIFF
--- a/servers/caddy/mesi.go
+++ b/servers/caddy/mesi.go
@@ -58,6 +58,11 @@ type MesiMiddleware struct {
 	// When empty, DefaultCacheKey (URL-only) is used.
 	CacheKeyTemplate string `json:"cache_key_template,omitempty"`
 
+	// IncludeErrorMarker is rendered in place of a failed include when no
+	// onerror="continue" and no fallback body is present. Default: "" (silent).
+	// SECURITY: Never include raw errors or URLs in the marker.
+	IncludeErrorMarker string `json:"include_error_marker,omitempty"`
+
 	// CacheRedisAddr is the Redis server address (host:port).
 	// Required when CacheBackend is "redis". Default: "localhost:6379".
 	CacheRedisAddr string `json:"cache_redis_addr,omitempty"`
@@ -189,11 +194,12 @@ func (m *MesiMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next 
 			depth = *m.MaxDepth
 		}
 		config := mesi.EsiParserConfig{
-			Context:         r.Context(),
-			MaxDepth:        uint(depth),
-			DefaultUrl:      middleware.GetDefaultUrl(r),
-			Timeout:         m.parsedTimeout,
-			BlockPrivateIPs: true,
+			Context:             r.Context(),
+			MaxDepth:            uint(depth),
+			DefaultUrl:          middleware.GetDefaultUrl(r),
+			Timeout:             m.parsedTimeout,
+			BlockPrivateIPs:     true,
+			IncludeErrorMarker:  m.IncludeErrorMarker,
 		}
 
 		if m.cache != nil {
@@ -301,12 +307,17 @@ func (m *MesiMiddleware) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.ArgErr()
 				}
 				m.CacheTTL = d.Val()
-			case "cache_key_template":
-				if !d.NextArg() {
-					return d.ArgErr()
-				}
-				m.CacheKeyTemplate = d.Val()
-			case "cache_redis_addr":
+		case "cache_key_template":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			m.CacheKeyTemplate = d.Val()
+		case "include_error_marker":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			m.IncludeErrorMarker = d.Val()
+		case "cache_redis_addr":
 				if !d.NextArg() {
 					return d.ArgErr()
 				}

--- a/servers/caddy/mesi.go
+++ b/servers/caddy/mesi.go
@@ -307,17 +307,17 @@ func (m *MesiMiddleware) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.ArgErr()
 				}
 				m.CacheTTL = d.Val()
-		case "cache_key_template":
-			if !d.NextArg() {
-				return d.ArgErr()
-			}
-			m.CacheKeyTemplate = d.Val()
-		case "include_error_marker":
-			if !d.NextArg() {
-				return d.ArgErr()
-			}
-			m.IncludeErrorMarker = d.Val()
-		case "cache_redis_addr":
+			case "cache_key_template":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				m.CacheKeyTemplate = d.Val()
+			case "include_error_marker":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				m.IncludeErrorMarker = d.Val()
+			case "cache_redis_addr":
 				if !d.NextArg() {
 					return d.ArgErr()
 				}

--- a/servers/caddy/mesi_test.go
+++ b/servers/caddy/mesi_test.go
@@ -1821,3 +1821,161 @@ func TestTimeoutIntegrationParseAndProvision(t *testing.T) {
 		t.Fatalf("Cleanup() returned error: %v", err)
 	}
 }
+
+// --- IncludeErrorMarker Tests ---
+
+// TestUnmarshalCaddyfileIncludeErrorMarker parses the include_error_marker directive.
+func TestUnmarshalCaddyfileIncludeErrorMarker(t *testing.T) {
+	input := `mesi {
+		include_error_marker "<!-- esi error -->"
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	m := &MesiMiddleware{}
+	err := m.UnmarshalCaddyfile(d)
+	if err != nil {
+		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
+	}
+	if m.IncludeErrorMarker != "<!-- esi error -->" {
+		t.Errorf("expected IncludeErrorMarker='<!-- esi error -->', got '%s'", m.IncludeErrorMarker)
+	}
+}
+
+// TestUnmarshalCaddyfileIncludeErrorMarkerNoArg verifies that include_error_marker
+// without argument returns ArgErr.
+func TestUnmarshalCaddyfileIncludeErrorMarkerNoArg(t *testing.T) {
+	input := `mesi {
+		include_error_marker
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	m := &MesiMiddleware{}
+	err := m.UnmarshalCaddyfile(d)
+	if err == nil {
+		t.Fatal("UnmarshalCaddyfile should return error for include_error_marker without argument")
+	}
+}
+
+// TestUnmarshalCaddyfileIncludeErrorMarkerEmpty verifies that include_error_marker
+// with an empty string sets the marker to empty.
+func TestUnmarshalCaddyfileIncludeErrorMarkerEmpty(t *testing.T) {
+	input := `mesi {
+		include_error_marker ""
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	m := &MesiMiddleware{}
+	err := m.UnmarshalCaddyfile(d)
+	if err != nil {
+		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
+	}
+	if m.IncludeErrorMarker != "" {
+		t.Errorf("expected IncludeErrorMarker='', got '%s'", m.IncludeErrorMarker)
+	}
+}
+
+// TestIncludeErrorMarkerDefaultUnset verifies that when include_error_marker
+// is not set, IncludeErrorMarker is empty.
+func TestIncludeErrorMarkerDefaultUnset(t *testing.T) {
+	m := &MesiMiddleware{}
+	if err := m.Provision(caddy.Context{}); err != nil {
+		t.Fatalf("Provision() returned error: %v", err)
+	}
+	if m.IncludeErrorMarker != "" {
+		t.Errorf("IncludeErrorMarker should be empty by default, got '%s'", m.IncludeErrorMarker)
+	}
+}
+
+// TestIncludeErrorMarkerProvision verifies that Provision works with IncludeErrorMarker set.
+func TestIncludeErrorMarkerProvision(t *testing.T) {
+	m := &MesiMiddleware{IncludeErrorMarker: "<!-- ESI_ERROR -->"}
+	if err := m.Provision(caddy.Context{}); err != nil {
+		t.Fatalf("Provision() returned error: %v", err)
+	}
+	if m.IncludeErrorMarker != "<!-- ESI_ERROR -->" {
+		t.Errorf("expected IncludeErrorMarker='<!-- ESI_ERROR -->', got '%s'", m.IncludeErrorMarker)
+	}
+}
+
+// TestIncludeErrorMarkerServeHTTP verifies that the configured IncludeErrorMarker
+// is passed to EsiParserConfig in ServeHTTP.
+func TestIncludeErrorMarkerServeHTTP(t *testing.T) {
+	m := &MesiMiddleware{IncludeErrorMarker: "<!-- esi error -->"}
+	if err := m.Provision(caddy.Context{}); err != nil {
+		t.Fatalf("Provision() returned error: %v", err)
+	}
+
+	fragmentServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("fragment"))
+	}))
+	defer fragmentServer.Close()
+
+	esiContent := `<html><body><esi:include src="` + fragmentServer.URL + `/frag" /></body></html>`
+	handler := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(esiContent))
+		return nil
+	})
+
+	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	rec := httptest.NewRecorder()
+
+	err := m.ServeHTTP(rec, req, handler)
+	if err != nil {
+		t.Fatalf("ServeHTTP returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", rec.Code)
+	}
+}
+
+// TestIncludeErrorMarkerWithOtherDirectives verifies include_error_marker
+// works alongside other directives.
+func TestIncludeErrorMarkerWithOtherDirectives(t *testing.T) {
+	input := `mesi {
+		max_depth 3
+		include_error_marker "<!-- ESI_FAIL -->"
+		shared_http_client
+		timeout 15s
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	m := &MesiMiddleware{}
+	if err := m.UnmarshalCaddyfile(d); err != nil {
+		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
+	}
+	if m.MaxDepth == nil || *m.MaxDepth != 3 {
+		t.Errorf("expected MaxDepth=3, got %v", m.MaxDepth)
+	}
+	if m.IncludeErrorMarker != "<!-- ESI_FAIL -->" {
+		t.Errorf("expected IncludeErrorMarker='<!-- ESI_FAIL -->', got '%s'", m.IncludeErrorMarker)
+	}
+	if !m.SharedHTTPClient {
+		t.Error("SharedHTTPClient should be true")
+	}
+	if m.Timeout != "15s" {
+		t.Errorf("expected Timeout='15s', got '%s'", m.Timeout)
+	}
+}
+
+// TestIncludeErrorMarkerIntegrationParseAndProvision verifies the full flow:
+// Caddyfile parsing → Provision → Cleanup with include_error_marker.
+func TestIncludeErrorMarkerIntegrationParseAndProvision(t *testing.T) {
+	input := `mesi {
+		include_error_marker "<!-- esi error: fragment failed -->"
+		max_depth 5
+		timeout 10s
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	m := &MesiMiddleware{}
+	if err := m.UnmarshalCaddyfile(d); err != nil {
+		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
+	}
+	if m.IncludeErrorMarker != "<!-- esi error: fragment failed -->" {
+		t.Errorf("expected IncludeErrorMarker='<!-- esi error: fragment failed -->', got '%s'", m.IncludeErrorMarker)
+	}
+	if err := m.Provision(caddy.Context{}); err != nil {
+		t.Fatalf("Provision() returned error: %v", err)
+	}
+	if err := m.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() returned error: %v", err)
+	}
+}


### PR DESCRIPTION
Adds the include_error_marker directive to the Caddy module, allowing operators to configure a marker string rendered when an ESI include fails and no onerror="continue" or fallback body is present.

## Changes
- Added  field to  struct
- Added  directive parsing in 
- Added mapping to  in 
- Added 8 unit tests covering parsing, defaults, provision, and integration

## Usage
```
mesi {
    include_error_marker "<!-- esi error -->"
}
```

## Security
- Marker is a static operator-configured string
- Never include error messages or URLs in the marker
- Marker renders only when no `onerror` and no fallback body on the tag

Closes #261