### PR TITLE
feat(traefik): add sharedHTTPClient config option

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -37,7 +37,7 @@ Support status of mESI features across all server integrations.
 | Cache (Memcached) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | Custom CacheKeyFunc | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | Recursive ESI processing | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Shared HTTPClient | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Shared HTTPClient | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 
 ## Legend
 

--- a/servers/traefik/README.md
+++ b/servers/traefik/README.md
@@ -22,6 +22,7 @@ http:
       plugin:
         mesi:
           maxDepth: 5
+          sharedHTTPClient: true
 
   routers:
     test-server:
@@ -33,6 +34,25 @@ http:
   services:
     test-server:
     # some service config here
+```
+
+## Shared HTTP Client
+
+When `sharedHTTPClient` is enabled, a shared `http.Transport` with SSRF protection
+is created once and reused for all ESI include requests. This enables TCP connection
+pooling (keep-alive), dramatically reducing latency for pages with multiple includes
+to the same backend origin.
+
+Without this option, each `<esi:include>` creates a fresh `http.Client` + `http.Transport`,
+incurring N × (TCP connect + TLS handshake) overhead.
+
+```yaml
+http:
+  middlewares:
+    mesi:
+      plugin:
+        mesi:
+          sharedHTTPClient: true
 ```
 
 ## Cache Backend
@@ -75,6 +95,7 @@ http:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
+| `sharedHTTPClient` | bool | `false` | Enable shared HTTP client for connection pooling |
 | `cacheBackend` | string | `""` | Cache backend: `""` (off), `memory`, `redis` |
 | `cacheTTL` | string | `""` | Cache TTL as Go duration (e.g., `"60s"`, `"5m"`) |
 | `cacheSize` | int | `10000` | Max entries for memory cache |

--- a/servers/traefik/mesi.go
+++ b/servers/traefik/mesi.go
@@ -16,6 +16,7 @@ const PluginName = "mesi"
 
 type Config struct {
 	MaxDepth           int    `json:"maxDepth" yaml:"maxDepth"`
+	SharedHTTPClient   bool   `json:"sharedHTTPClient" yaml:"sharedHTTPClient"`
 	CacheBackend       string `json:"cacheBackend" yaml:"cacheBackend"`
 	CacheTTL           string `json:"cacheTTL" yaml:"cacheTTL"`
 	CacheSize          int    `json:"cacheSize" yaml:"cacheSize"`
@@ -31,12 +32,13 @@ func CreateConfig() *Config {
 }
 
 type ResponsePlugin struct {
-	next     http.Handler
-	name     string
-	config   *Config
-	cache    mesi.Cache
-	cacheTTL time.Duration
-	closeFn  func() error
+	next            http.Handler
+	name            string
+	config          *Config
+	cache           mesi.Cache
+	cacheTTL        time.Duration
+	sharedTransport *http.Transport
+	closeFn         func() error
 }
 
 func New(ctx context.Context, next http.Handler, config *Config, name string) (http.Handler, error) {
@@ -52,6 +54,12 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 		next:   next,
 		name:   name,
 		config: config,
+	}
+
+	if config.SharedHTTPClient {
+		p.sharedTransport = mesi.NewSSRFSafeTransport(mesi.EsiParserConfig{
+			BlockPrivateIPs: true,
+		})
 	}
 
 	if config.CacheBackend != "" && config.CacheTTL != "" {
@@ -95,6 +103,13 @@ func (p *ResponsePlugin) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			config.CacheTTL = p.cacheTTL
 		}
 
+		if p.sharedTransport != nil {
+			config.HTTPClient = &http.Client{
+				Transport: p.sharedTransport,
+				Timeout:   config.Timeout,
+			}
+		}
+
 		processedResponse := mesi.MESIParse(
 			customWriter.Body().String(),
 			config,
@@ -118,6 +133,9 @@ func (p *ResponsePlugin) Name() string {
 }
 
 func (p *ResponsePlugin) Close() error {
+	if p.sharedTransport != nil {
+		p.sharedTransport.CloseIdleConnections()
+	}
 	if p.closeFn != nil {
 		return p.closeFn()
 	}

--- a/servers/traefik/shared_http_client_test.go
+++ b/servers/traefik/shared_http_client_test.go
@@ -1,0 +1,91 @@
+package traefik
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestNewSharedHTTPClient(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	config := CreateConfig()
+	config.SharedHTTPClient = true
+
+	p, err := New(context.Background(), handler, config, "test")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	plugin := p.(*ResponsePlugin)
+	if plugin.sharedTransport == nil {
+		t.Fatal("Expected non-nil sharedTransport when SharedHTTPClient is true")
+	}
+}
+
+func TestNewWithoutSharedHTTPClient(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	config := CreateConfig()
+
+	p, err := New(context.Background(), handler, config, "test")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	plugin := p.(*ResponsePlugin)
+	if plugin.sharedTransport != nil {
+		t.Fatal("Expected nil sharedTransport when SharedHTTPClient is false")
+	}
+}
+
+func TestSharedHTTPClientTransportIsSSRFSafe(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	config := CreateConfig()
+	config.SharedHTTPClient = true
+
+	p, err := New(context.Background(), handler, config, "test")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	plugin := p.(*ResponsePlugin)
+	if plugin.sharedTransport == nil {
+		t.Fatal("Expected non-nil sharedTransport")
+	}
+
+	if plugin.sharedTransport.DialContext == nil {
+		t.Fatal("Expected DialContext to be set (SSRF-safe transport)")
+	}
+}
+
+func TestCloseWithSharedHTTPClient(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	config := CreateConfig()
+	config.SharedHTTPClient = true
+
+	p, err := New(context.Background(), handler, config, "test")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	plugin := p.(*ResponsePlugin)
+	err = plugin.Close()
+	if err != nil {
+		t.Fatalf("Unexpected error closing plugin: %v", err)
+	}
+}
+
+func TestCloseWithoutSharedHTTPClient(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	config := CreateConfig()
+
+	p, err := New(context.Background(), handler, config, "test")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	plugin := p.(*ResponsePlugin)
+	err = plugin.Close()
+	if err != nil {
+		t.Fatalf("Unexpected error closing plugin: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `sharedHTTPClient` config option to the Traefik plugin for TCP connection pooling of ESI includes.

## Problem

Without this option, each `<esi:include>` creates a fresh `http.Client` + `http.Transport`. For pages with N includes to the same backend, this incurs N x (TCP connect + TLS handshake) overhead.

## Solution

When `sharedHTTPClient: true` is set, a shared `http.Transport` with SSRF protection (`mesi.NewSSRFSafeTransport`) is created once in `New()` and reused for all requests. Go's `http.Transport` pools idle connections (default: 100 per host, 90s idle timeout).

## Changes

- `servers/traefik/mesi.go`: Added `SharedHTTPClient` to `Config`, `sharedTransport` to `ResponsePlugin`, transport init in `New()`, transport usage in `ServeHTTP()`, cleanup in `Close()`
- `servers/traefik/shared_http_client_test.go`: Unit tests for shared transport creation, SSRF safety, and cleanup
- `servers/traefik/README.md`: Documentation for the new option
- `docs/features.md`: Updated feature matrix

## Config

```yaml
http:
  middlewares:
    mesi:
      plugin:
        mesi:
          sharedHTTPClient: true
```

Closes #249
