### PR TITLE
feat(roadrunner): add shared_http_client config option (#250)

### DIFF
--- a/servers/roadrunner/README.md
+++ b/servers/roadrunner/README.md
@@ -48,8 +48,6 @@ http:
 | `cache_redis_password` | string | `""` | Redis AUTH password. |
 | `cache_redis_db` | int | `0` | Redis database number. |
 
-### Options
-
 #### Shared HTTP Client
 Enables TCP connection reuse across ESI includes. The shared client uses an SSRF-safe transport that blocks private IPs.
 

--- a/servers/roadrunner/README.md
+++ b/servers/roadrunner/README.md
@@ -38,6 +38,7 @@ http:
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `max_depth` | int | `5` | Maximum ESI nesting depth. Set to `0` to disable ESI processing. |
+| `shared_http_client` | bool | `false` | Reuse a single HTTP client for all ESI includes (SSRF-safe, connection pooling). |
 | `timeout` | string | `"10s"` | Maximum time for ESI processing (Go duration format). |
 | `include_error_marker` | string | `""` | HTML marker rendered for failed includes (no `onerror="continue"`). |
 | `cache_backend` | string | `""` | Cache backend: `""` (off), `"memory"`, `"redis"`. |
@@ -46,6 +47,18 @@ http:
 | `cache_redis_addr` | string | `"localhost:6379"` | Redis server address (host:port). |
 | `cache_redis_password` | string | `""` | Redis AUTH password. |
 | `cache_redis_db` | int | `0` | Redis database number. |
+
+### Options
+
+#### Shared HTTP Client
+Enables TCP connection reuse across ESI includes. The shared client uses an SSRF-safe transport that blocks private IPs.
+
+```yaml
+http:
+  middleware:
+    mesi:
+      shared_http_client: true
+```
 
 ### Cache backends
 

--- a/servers/roadrunner/mesi.go
+++ b/servers/roadrunner/mesi.go
@@ -14,16 +14,17 @@ import (
 const PluginName = "mesi"
 
 type Config struct {
-	MaxDepth           int      `mapstructure:"max_depth"`
-	CacheBackend       string   `mapstructure:"cache_backend"`
-	CacheSize          int      `mapstructure:"cache_size"`
-	CacheTTL           string   `mapstructure:"cache_ttl"`
-	CacheRedisAddr     string   `mapstructure:"cache_redis_addr"`
-	CacheRedisPassword string   `mapstructure:"cache_redis_password"`
-	CacheRedisDB       int      `mapstructure:"cache_redis_db"`
+	MaxDepth              int      `mapstructure:"max_depth"`
+	SharedHTTPClient      bool     `mapstructure:"shared_http_client"`
+	CacheBackend          string   `mapstructure:"cache_backend"`
+	CacheSize             int      `mapstructure:"cache_size"`
+	CacheTTL              string   `mapstructure:"cache_ttl"`
+	CacheRedisAddr        string   `mapstructure:"cache_redis_addr"`
+	CacheRedisPassword    string   `mapstructure:"cache_redis_password"`
+	CacheRedisDB          int      `mapstructure:"cache_redis_db"`
 	CacheMemcachedServers []string `mapstructure:"cache_memcached_servers"`
-	Timeout            string   `mapstructure:"timeout"`
-	IncludeErrorMarker string   `mapstructure:"include_error_marker"`
+	Timeout               string   `mapstructure:"timeout"`
+	IncludeErrorMarker    string   `mapstructure:"include_error_marker"`
 }
 
 func CreateConfig() *Config {
@@ -33,10 +34,11 @@ func CreateConfig() *Config {
 }
 
 type Plugin struct {
-	config   *Config
-	cache    mesi.Cache
-	cacheTTL time.Duration
-	closeFn  func() error
+	config          *Config
+	cache           mesi.Cache
+	cacheTTL        time.Duration
+	sharedTransport *http.Transport
+	closeFn         func() error
 }
 
 func (p *Plugin) Init() error {
@@ -46,6 +48,12 @@ func (p *Plugin) Init() error {
 
 	if p.config.MaxDepth == 0 {
 		p.config.MaxDepth = 5
+	}
+
+	if p.config.SharedHTTPClient {
+		p.sharedTransport = mesi.NewSSRFSafeTransport(mesi.EsiParserConfig{
+			BlockPrivateIPs: true,
+		})
 	}
 
 	if p.config.CacheBackend != "" && p.config.CacheTTL != "" {
@@ -87,6 +95,13 @@ func (p *Plugin) Middleware(next http.Handler) http.Handler {
 				config.CacheTTL = p.cacheTTL
 			}
 
+			if p.sharedTransport != nil {
+				config.HTTPClient = &http.Client{
+					Transport: p.sharedTransport,
+					Timeout:   config.Timeout,
+				}
+			}
+
 			processedResponse := mesi.MESIParse(
 				customWriter.Body().String(),
 				config,
@@ -111,6 +126,9 @@ func (p *Plugin) Name() string {
 }
 
 func (p *Plugin) Close() error {
+	if p.sharedTransport != nil {
+		p.sharedTransport.CloseIdleConnections()
+	}
 	if p.closeFn != nil {
 		return p.closeFn()
 	}

--- a/servers/roadrunner/shared_http_client_test.go
+++ b/servers/roadrunner/shared_http_client_test.go
@@ -1,0 +1,99 @@
+package roadrunner
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestInitSharedHTTPClient(t *testing.T) {
+	config := CreateConfig()
+	config.SharedHTTPClient = true
+
+	p := &Plugin{config: config}
+	if err := p.Init(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if p.sharedTransport == nil {
+		t.Fatal("Expected non-nil sharedTransport when SharedHTTPClient is true")
+	}
+}
+
+func TestInitWithoutSharedHTTPClient(t *testing.T) {
+	config := CreateConfig()
+
+	p := &Plugin{config: config}
+	if err := p.Init(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if p.sharedTransport != nil {
+		t.Fatal("Expected nil sharedTransport when SharedHTTPClient is false")
+	}
+}
+
+func TestSharedHTTPClientTransportIsSSRFSafe(t *testing.T) {
+	config := CreateConfig()
+	config.SharedHTTPClient = true
+
+	p := &Plugin{config: config}
+	if err := p.Init(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if p.sharedTransport == nil {
+		t.Fatal("Expected non-nil sharedTransport")
+	}
+
+	if p.sharedTransport.DialContext == nil {
+		t.Fatal("Expected DialContext to be set (SSRF-safe transport)")
+	}
+}
+
+func TestCloseWithSharedHTTPClient(t *testing.T) {
+	config := CreateConfig()
+	config.SharedHTTPClient = true
+
+	p := &Plugin{config: config}
+	if err := p.Init(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("Unexpected error closing plugin: %v", err)
+	}
+}
+
+func TestCloseWithoutSharedHTTPClient(t *testing.T) {
+	p := &Plugin{}
+	if err := p.Close(); err != nil {
+		t.Fatalf("Unexpected error closing plugin: %v", err)
+	}
+}
+
+func TestMiddlewareWithSharedHTTPClient(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("<html><body>content</body></html>"))
+	})
+
+	config := CreateConfig()
+	config.SharedHTTPClient = true
+
+	p := &Plugin{config: config}
+	if err := p.Init(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	middleware := p.Middleware(handler)
+	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	rec := httptest.NewRecorder()
+
+	middleware.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary

Adds  config option to the RoadRunner plugin, enabling TCP connection reuse across ESI includes with SSRF-safe transport.

## Changes

- Add  to Config struct ()
- Add  to Plugin struct
- Init SSRF-safe transport in  when enabled
- Attach shared HTTP client to  in 
- Close idle connections in 
- Add unit tests for init, SSRF safety, close, and middleware
- Update README with configuration docs

## Config

```yaml
http:
  middleware:
    mesi:
      shared_http_client: true
```

## Motivation

Without this option, each ESI include creates a fresh `http.Client`, which means no TCP connection reuse. This feature enables connection pooling for significant performance improvements in setups with many ESI includes.

Closes #250