### PR TITLE
feat(caddy): add block_private_ips Caddyfile directive

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -24,7 +24,7 @@ Support status of mESI features across all server integrations.
 | `IncludeErrorMarker` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ⚠️ | ✅ |
 | Global MaxDepth | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
 | Global Timeout | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
-| SSRF (BlockPrivateIPs) | ✅ | 🔒 | 🔒 | 🔒 | ❌ | ✅ | ❌ | 🔒 | ✅ |
+| SSRF (BlockPrivateIPs) | ✅ | 🔒 | 🔒 | ✅ | ❌ | ✅ | ❌ | 🔒 | ✅ |
 | AllowedHosts | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ |
 | AllowPrivateIPsForAllowedHosts | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | MaxResponseSize | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |

--- a/servers/caddy/mesi.go
+++ b/servers/caddy/mesi.go
@@ -93,6 +93,11 @@ type MesiMiddleware struct {
 	// Provision time. Default: "10s".
 	Timeout string `json:"timeout,omitempty"`
 
+	// BlockPrivateIPs controls SSRF protection. When true (default),
+	// ESI includes to private/reserved IPs are blocked. Set to false
+	// to allow internal ESI includes (e.g. service meshes, metadata services).
+	BlockPrivateIPs *bool `json:"block_private_ips,omitempty"`
+
 	sharedTransport *http.Transport  `json:"-"`
 	cache           mesi.Cache       `json:"-"`
 	cacheTTL        time.Duration    `json:"-"`
@@ -110,9 +115,14 @@ func (m *MesiMiddleware) CaddyModule() caddy.ModuleInfo {
 
 // Provision implements caddy.Provisioner. Called once at config load.
 func (m *MesiMiddleware) Provision(ctx caddy.Context) error {
+	blockPrivateIPs := true
+	if m.BlockPrivateIPs != nil {
+		blockPrivateIPs = *m.BlockPrivateIPs
+	}
+
 	if m.SharedHTTPClient {
 		m.sharedTransport = mesi.NewSSRFSafeTransport(mesi.EsiParserConfig{
-			BlockPrivateIPs: true,
+			BlockPrivateIPs: blockPrivateIPs,
 		})
 	}
 
@@ -206,12 +216,16 @@ func (m *MesiMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next 
 		if m.MaxDepth != nil {
 			depth = *m.MaxDepth
 		}
+		blockPrivateIPs := true
+		if m.BlockPrivateIPs != nil {
+			blockPrivateIPs = *m.BlockPrivateIPs
+		}
 		config := mesi.EsiParserConfig{
 			Context:                r.Context(),
 			MaxDepth:               uint(depth),
 			DefaultUrl:             middleware.GetDefaultUrl(r),
 			Timeout:                m.parsedTimeout,
-			BlockPrivateIPs:        true,
+			BlockPrivateIPs:        blockPrivateIPs,
 			AllowedHosts:           m.AllowedHosts,
 			IncludeErrorMarker:     m.IncludeErrorMarker,
 			Debug:                  m.Debug,
@@ -313,6 +327,17 @@ func (m *MesiMiddleware) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				}
 		case "shared_http_client":
 			m.SharedHTTPClient = true
+		case "block_private_ips":
+			if d.NextArg() {
+				v, err := strconv.ParseBool(d.Val())
+				if err != nil {
+					return d.Errf("invalid block_private_ips %q: %v", d.Val(), err)
+				}
+				m.BlockPrivateIPs = &v
+			} else {
+				v := true
+				m.BlockPrivateIPs = &v
+			}
 		case "allowed_hosts":
 			m.AllowedHosts = d.RemainingArgs()
 		case "debug":

--- a/servers/caddy/mesi_test.go
+++ b/servers/caddy/mesi_test.go
@@ -2496,3 +2496,121 @@ func TestMaxConcurrentRequestsIntegrationLimitsConcurrency(t *testing.T) {
 		t.Errorf("expected max 2 concurrent requests, got %d", peak)
 	}
 }
+
+// TestBlockPrivateIPsDefault verifies that BlockPrivateIPs defaults to true
+// when the directive is absent.
+func TestBlockPrivateIPsDefault(t *testing.T) {
+	m := &MesiMiddleware{}
+	if err := m.Provision(caddy.Context{}); err != nil {
+		t.Fatalf("Provision() returned error: %v", err)
+	}
+	if m.BlockPrivateIPs != nil {
+		t.Errorf("BlockPrivateIPs should be nil by default, got %v", *m.BlockPrivateIPs)
+	}
+}
+
+// TestBlockPrivateIPsProvisionTrue verifies that Provision works with BlockPrivateIPs=true.
+func TestBlockPrivateIPsProvisionTrue(t *testing.T) {
+	v := true
+	m := &MesiMiddleware{BlockPrivateIPs: &v}
+	if err := m.Provision(caddy.Context{}); err != nil {
+		t.Fatalf("Provision() returned error: %v", err)
+	}
+	if m.BlockPrivateIPs == nil || !*m.BlockPrivateIPs {
+		t.Error("BlockPrivateIPs should be true")
+	}
+}
+
+// TestBlockPrivateIPsProvisionFalse verifies that Provision works with BlockPrivateIPs=false.
+func TestBlockPrivateIPsProvisionFalse(t *testing.T) {
+	v := false
+	m := &MesiMiddleware{BlockPrivateIPs: &v}
+	if err := m.Provision(caddy.Context{}); err != nil {
+		t.Fatalf("Provision() returned error: %v", err)
+	}
+	if m.BlockPrivateIPs == nil || *m.BlockPrivateIPs {
+		t.Error("BlockPrivateIPs should be false")
+	}
+}
+
+// TestUnmarshalCaddyfileBlockPrivateIPsTrue parses the directive with explicit true.
+func TestUnmarshalCaddyfileBlockPrivateIPsTrue(t *testing.T) {
+	input := `mesi {
+		block_private_ips true
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	m := &MesiMiddleware{}
+	err := m.UnmarshalCaddyfile(d)
+	if err != nil {
+		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
+	}
+	if m.BlockPrivateIPs == nil || !*m.BlockPrivateIPs {
+		t.Error("BlockPrivateIPs should be true after parsing block_private_ips true")
+	}
+}
+
+// TestUnmarshalCaddyfileBlockPrivateIPsFalse parses the directive with false.
+func TestUnmarshalCaddyfileBlockPrivateIPsFalse(t *testing.T) {
+	input := `mesi {
+		block_private_ips false
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	m := &MesiMiddleware{}
+	err := m.UnmarshalCaddyfile(d)
+	if err != nil {
+		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
+	}
+	if m.BlockPrivateIPs == nil || *m.BlockPrivateIPs {
+		t.Error("BlockPrivateIPs should be false after parsing block_private_ips false")
+	}
+}
+
+// TestUnmarshalCaddyfileBlockPrivateIPsNoArg parses the directive without argument
+// (flag style) and defaults to true.
+func TestUnmarshalCaddyfileBlockPrivateIPsNoArg(t *testing.T) {
+	input := `mesi {
+		block_private_ips
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	m := &MesiMiddleware{}
+	err := m.UnmarshalCaddyfile(d)
+	if err != nil {
+		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
+	}
+	if m.BlockPrivateIPs == nil || !*m.BlockPrivateIPs {
+		t.Error("BlockPrivateIPs should be true when used as flag without argument")
+	}
+}
+
+// TestUnmarshalCaddyfileBlockPrivateIPsInvalid parses the directive with an invalid value.
+func TestUnmarshalCaddyfileBlockPrivateIPsInvalid(t *testing.T) {
+	input := `mesi {
+		block_private_ips invalid
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	m := &MesiMiddleware{}
+	err := m.UnmarshalCaddyfile(d)
+	if err == nil {
+		t.Fatal("UnmarshalCaddyfile should return error for invalid block_private_ips value")
+	}
+	if !strings.Contains(err.Error(), "invalid block_private_ips") {
+		t.Errorf("Expected 'invalid block_private_ips' error, got: %v", err)
+	}
+}
+
+// TestUnmarshalCaddyfileBlockPrivateIPsAbsent verifies the directive is not set
+// when absent from Caddyfile.
+func TestUnmarshalCaddyfileBlockPrivateIPsAbsent(t *testing.T) {
+	input := `mesi {
+		debug
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	m := &MesiMiddleware{}
+	err := m.UnmarshalCaddyfile(d)
+	if err != nil {
+		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
+	}
+	if m.BlockPrivateIPs != nil {
+		t.Error("BlockPrivateIPs should be nil when directive is absent")
+	}
+}


### PR DESCRIPTION
## Summary

Adds configurable  directive to the Caddy integration, allowing operators to disable SSRF protection for legitimate internal ESI includes (service meshes, internal metadata services).

## Changes

- Add  field to  struct
- Parse  directive in  (supports //no-arg flag)
- Use configured value in  and  (shared transport)
- Default remains  (backward compatible, no breaking change)
- Add comprehensive unit tests (8 test cases)
- Update feature matrix: Caddy SSRF now configurable (was hardcoded)

## Caddyfile usage

```caddyfile
mesi {
    block_private_ips false  # Allow internal ESI includes
}
```

Or as a flag (defaults to true):

```caddyfile
mesi {
    block_private_ips  # Explicitly enable (same as default)
}
```

## Testing

- 8 new unit tests covering: default, true, false, no-arg flag, invalid value, absent directive
- All 406 tests pass across the entire project
-  reports no issues

Closes #254