### PR TITLE
feat(roadrunner): add cache_key_template config option

### DIFF
--- a/mesi/cache_key_template.go
+++ b/mesi/cache_key_template.go
@@ -1,0 +1,37 @@
+package mesi
+
+import (
+	"net/http"
+	"strings"
+)
+
+// BuildCacheKey evaluates a cache key template string, substituting placeholders
+// with values from the URL and HTTP request.
+//
+// Supported placeholders:
+//   - ${url}            — the include URL
+//   - ${header:Name}    — request header value (supports canonical, lowercase, uppercase forms)
+//   - ${cookie:Name}    — cookie value (supports canonical, lowercase, uppercase forms)
+//
+// Unknown placeholders are left as literals.
+func BuildCacheKey(url string, template string, r *http.Request) string {
+	result := template
+	result = strings.ReplaceAll(result, "${url}", url)
+
+	// ${header:Name} substitution
+	for key, vals := range r.Header {
+		val := vals[0]
+		result = strings.ReplaceAll(result, "${header:"+key+"}", val)
+		result = strings.ReplaceAll(result, "${header:"+strings.ToLower(key)+"}", val)
+		result = strings.ReplaceAll(result, "${header:"+strings.ToUpper(key)+"}", val)
+	}
+
+	// ${cookie:Name} substitution
+	for _, c := range r.Cookies() {
+		result = strings.ReplaceAll(result, "${cookie:"+c.Name+"}", c.Value)
+		result = strings.ReplaceAll(result, "${cookie:"+strings.ToLower(c.Name)+"}", c.Value)
+		result = strings.ReplaceAll(result, "${cookie:"+strings.ToUpper(c.Name)+"}", c.Value)
+	}
+
+	return result
+}

--- a/mesi/cache_key_template_test.go
+++ b/mesi/cache_key_template_test.go
@@ -1,0 +1,82 @@
+package mesi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBuildCacheKey_URL(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://example.com/", nil)
+	key := BuildCacheKey("http://backend/frag", "mesi:${url}", r)
+	if key != "mesi:http://backend/frag" {
+		t.Errorf("expected 'mesi:http://backend/frag', got '%s'", key)
+	}
+}
+
+func TestBuildCacheKey_Header(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://example.com/", nil)
+	r.Header.Set("Accept-Language", "pl")
+
+	// canonical form
+	key := BuildCacheKey("/frag", "mesi:${url}:${header:Accept-Language}", r)
+	if key != "mesi:/frag:pl" {
+		t.Errorf("expected 'mesi:/frag:pl', got '%s'", key)
+	}
+
+	// lowercase form
+	key = BuildCacheKey("/frag", "mesi:${url}:${header:accept-language}", r)
+	if key != "mesi:/frag:pl" {
+		t.Errorf("expected 'mesi:/frag:pl', got '%s'", key)
+	}
+
+	// uppercase form
+	key = BuildCacheKey("/frag", "mesi:${url}:${header:ACCEPT-LANGUAGE}", r)
+	if key != "mesi:/frag:pl" {
+		t.Errorf("expected 'mesi:/frag:pl', got '%s'", key)
+	}
+}
+
+func TestBuildCacheKey_Cookie(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://example.com/", nil)
+	r.AddCookie(&http.Cookie{Name: "session", Value: "abc123"})
+
+	// canonical form
+	key := BuildCacheKey("/frag", "mesi:${url}:${cookie:session}", r)
+	if key != "mesi:/frag:abc123" {
+		t.Errorf("expected 'mesi:/frag:abc123', got '%s'", key)
+	}
+
+	// lowercase form
+	key = BuildCacheKey("/frag", "mesi:${url}:${cookie:session}", r)
+	if key != "mesi:/frag:abc123" {
+		t.Errorf("expected 'mesi:/frag:abc123', got '%s'", key)
+	}
+}
+
+func TestBuildCacheKey_UnknownPlaceholder(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://example.com/", nil)
+	key := BuildCacheKey("/frag", "mesi:${url}:${unknown:foo}", r)
+	if key != "mesi:/frag:${unknown:foo}" {
+		t.Errorf("expected 'mesi:/frag:${unknown:foo}', got '%s'", key)
+	}
+}
+
+func TestBuildCacheKey_MultiplePlaceholders(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://example.com/", nil)
+	r.Header.Set("Accept-Language", "en")
+	r.AddCookie(&http.Cookie{Name: "ab_test", Value: "B"})
+
+	key := BuildCacheKey("/frag", "${url}:${header:Accept-Language}:${cookie:ab_test}", r)
+	if key != "/frag:en:B" {
+		t.Errorf("expected '/frag:en:B', got '%s'", key)
+	}
+}
+
+func TestBuildCacheKey_EmptyTemplate(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://example.com/", nil)
+	key := BuildCacheKey("/frag", "", r)
+	if key != "" {
+		t.Errorf("expected empty string, got '%s'", key)
+	}
+}

--- a/servers/caddy/mesi.go
+++ b/servers/caddy/mesi.go
@@ -238,25 +238,7 @@ func (m *MesiMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next 
 			if m.CacheKeyTemplate != "" {
 				tmpl := m.CacheKeyTemplate
 				config.CacheKeyFunc = func(url string) string {
-					result := strings.ReplaceAll(tmpl, "${url}", url)
-
-					// ${header:Name} substitution
-					// Supports canonical, lowercase, and uppercase forms.
-					for key, vals := range r.Header {
-						val := vals[0]
-						result = strings.ReplaceAll(result, "${header:"+key+"}", val)
-						result = strings.ReplaceAll(result, "${header:"+strings.ToLower(key)+"}", val)
-						result = strings.ReplaceAll(result, "${header:"+strings.ToUpper(key)+"}", val)
-					}
-
-					// ${cookie:Name} substitution
-					for _, c := range r.Cookies() {
-						result = strings.ReplaceAll(result, "${cookie:"+c.Name+"}", c.Value)
-						result = strings.ReplaceAll(result, "${cookie:"+strings.ToLower(c.Name)+"}", c.Value)
-						result = strings.ReplaceAll(result, "${cookie:"+strings.ToUpper(c.Name)+"}", c.Value)
-					}
-
-					return result
+					return mesi.BuildCacheKey(url, tmpl, r)
 				}
 			}
 		}

--- a/servers/roadrunner/README.md
+++ b/servers/roadrunner/README.md
@@ -44,6 +44,7 @@ http:
 | `cache_backend` | string | `""` | Cache backend: `""` (off), `"memory"`, `"redis"`. |
 | `cache_size` | int | `10000` | Max entries for memory cache backend. |
 | `cache_ttl` | string | `""` | Default TTL for cached entries, e.g. `"60s"`. |
+| `cache_key_template` | string | `""` | Custom cache key template (see below). |
 | `cache_redis_addr` | string | `"localhost:6379"` | Redis server address (host:port). |
 | `cache_redis_password` | string | `""` | Redis AUTH password. |
 | `cache_redis_db` | int | `0` | Redis database number. |
@@ -85,5 +86,24 @@ http:
       cache_redis_addr: "10.0.0.5:6379"
       cache_redis_db: 2
 ```
+
+#### Cache Key Template
+Customize cache keys based on request headers or cookies. Useful for multi-language sites or A/B testing.
+
+```yaml
+http:
+  middleware:
+    mesi:
+      cache_backend: memory
+      cache_ttl: "60s"
+      cache_key_template: "mesi:${url}:${header:Accept-Language}"
+```
+
+**Template placeholders:**
+- `${url}` — the include URL
+- `${header:Name}` — request header value (supports canonical, lowercase, uppercase forms)
+- `${cookie:Name}` — cookie value (supports canonical, lowercase, uppercase forms)
+
+Unknown placeholders are left as literals.
 
 An example script with the appropriate configuration can be found in the [worker](worker) directory

--- a/servers/roadrunner/mesi.go
+++ b/servers/roadrunner/mesi.go
@@ -19,6 +19,7 @@ type Config struct {
 	CacheBackend          string   `mapstructure:"cache_backend"`
 	CacheSize             int      `mapstructure:"cache_size"`
 	CacheTTL              string   `mapstructure:"cache_ttl"`
+	CacheKeyTemplate      string   `mapstructure:"cache_key_template"`
 	CacheRedisAddr        string   `mapstructure:"cache_redis_addr"`
 	CacheRedisPassword    string   `mapstructure:"cache_redis_password"`
 	CacheRedisDB          int      `mapstructure:"cache_redis_db"`
@@ -90,10 +91,16 @@ func (p *Plugin) Middleware(next http.Handler) http.Handler {
 				IncludeErrorMarker: p.config.IncludeErrorMarker,
 			}
 
-			if p.cache != nil {
-				config.Cache = p.cache
-				config.CacheTTL = p.cacheTTL
+		if p.cache != nil {
+			config.Cache = p.cache
+			config.CacheTTL = p.cacheTTL
+			if p.config.CacheKeyTemplate != "" {
+				tmpl := p.config.CacheKeyTemplate
+				config.CacheKeyFunc = func(url string) string {
+					return mesi.BuildCacheKey(url, tmpl, r)
+				}
 			}
+		}
 
 			if p.sharedTransport != nil {
 				config.HTTPClient = &http.Client{

--- a/servers/roadrunner/mesi.go
+++ b/servers/roadrunner/mesi.go
@@ -91,16 +91,16 @@ func (p *Plugin) Middleware(next http.Handler) http.Handler {
 				IncludeErrorMarker: p.config.IncludeErrorMarker,
 			}
 
-		if p.cache != nil {
-			config.Cache = p.cache
-			config.CacheTTL = p.cacheTTL
-			if p.config.CacheKeyTemplate != "" {
-				tmpl := p.config.CacheKeyTemplate
-				config.CacheKeyFunc = func(url string) string {
-					return mesi.BuildCacheKey(url, tmpl, r)
+			if p.cache != nil {
+				config.Cache = p.cache
+				config.CacheTTL = p.cacheTTL
+				if p.config.CacheKeyTemplate != "" {
+					tmpl := p.config.CacheKeyTemplate
+					config.CacheKeyFunc = func(url string) string {
+						return mesi.BuildCacheKey(url, tmpl, r)
+					}
 				}
 			}
-		}
 
 			if p.sharedTransport != nil {
 				config.HTTPClient = &http.Client{

--- a/servers/roadrunner/mesi_test.go
+++ b/servers/roadrunner/mesi_test.go
@@ -211,3 +211,32 @@ func TestMiddlewareIncludeErrorMarker(t *testing.T) {
 		t.Errorf("Expected include_error_marker '<!-- esi error -->', got %s", p.config.IncludeErrorMarker)
 	}
 }
+
+func TestInitCacheKeyTemplate(t *testing.T) {
+	config := CreateConfig()
+	config.CacheBackend = "memory"
+	config.CacheTTL = "60s"
+	config.CacheKeyTemplate = "mesi:${url}:${header:Accept-Language}"
+
+	p := &Plugin{config: config}
+	if err := p.Init(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if p.config.CacheKeyTemplate != "mesi:${url}:${header:Accept-Language}" {
+		t.Errorf("Expected cache_key_template 'mesi:${url}:${header:Accept-Language}', got %s", p.config.CacheKeyTemplate)
+	}
+}
+
+func TestInitCacheKeyTemplateDefaultEmpty(t *testing.T) {
+	config := CreateConfig()
+	config.CacheBackend = "memory"
+	config.CacheTTL = "60s"
+
+	p := &Plugin{config: config}
+	if err := p.Init(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if p.config.CacheKeyTemplate != "" {
+		t.Errorf("Expected empty cache_key_template, got %s", p.config.CacheKeyTemplate)
+	}
+}


### PR DESCRIPTION
## Summary

Add template-based cache key support for RoadRunner integration, matching Caddy's existing implementation.

Closes #247

## Changes

- **mesi package**: Add shared  function for template-based cache key evaluation (reusable across all server integrations)
- **RoadRunner**: Add  config field, wire  in 
- **Caddy**: Refactor to use shared  (DRY)
- **Tests**: Unit tests for  and RoadRunner config parsing
- **Docs**: Update RoadRunner README with cache_key_template documentation

## Template placeholders

- `${url}` — include URL
- `${header:Name}` — request header (supports canonical, lowercase, uppercase forms)
- `${cookie:Name}` — cookie value (supports canonical, lowercase, uppercase forms)

## Example

```yaml
http:
  middleware:
    mesi:
      cache_backend: memory
      cache_ttl: 60s
      cache_key_template: "mesi:${url}:${header:Accept-Language}"
```

## Testing

- [x] All mesi package tests pass (412)
- [x] All RoadRunner tests pass (21)
- [x] All Caddy tests pass (125)
- [x] `go vet` clean