### PR TITLE
feat(caddy): add max_response_size directive

### DIFF
--- a/servers/caddy/README.md
+++ b/servers/caddy/README.md
@@ -279,3 +279,32 @@ mesi {
   complex ESI pages with many tokens.
 - This is distinct from `max_concurrent_requests` — that limits HTTP fetches,
   while `max_workers` limits internal parallelism of ESI tag parsing.
+
+### `max_response_size`
+
+Limits the size (in bytes) of an individual `<esi:include>` response.
+Responses exceeding this limit are treated as errors — the include is replaced
+with the `include_error_marker` (or silently dropped if no marker is set).
+
+This is a security directive: it prevents a malicious or misconfigured backend
+from returning an unbounded response that exhausts Caddy's memory.
+
+```
+mesi {
+    max_response_size 1048576   # 1 MB
+}
+```
+
+| Value | Behaviour |
+|---|---|
+| `1–N` | Include responses larger than N bytes are rejected. |
+| `0` | Unlimited (no size check). |
+| absent | Library default: `10485760` (10 MB). |
+
+**Notes:**
+- Values are in bytes. For common sizes: `1048576` = 1 MB, `10485760` = 10 MB, `1073741824` = 1 GB.
+- When a response exceeds the limit, the include is replaced with the
+  `include_error_marker` string (if configured) or silently dropped.
+- This limit applies to each individual include response, not the total page size.
+- Consider setting this to a reasonable value based on the largest expected
+  include fragment in your application.

--- a/servers/caddy/mesi.go
+++ b/servers/caddy/mesi.go
@@ -100,9 +100,9 @@ type MesiMiddleware struct {
 
 	// MaxResponseSize limits the size (in bytes) of an individual ESI include
 	// response. Responses exceeding this limit are treated as errors and replaced
-	// with IncludeErrorMarker (or silently dropped). 0 = unlimited, but note the
-	// library default is 10 MB when this is left unset at the config level.
-	MaxResponseSize int64 `json:"max_response_size,omitempty"`
+	// with IncludeErrorMarker (or silently dropped). Pointer distinguishes "unset"
+	// (nil → library default 10 MB) from "explicitly set to 0" (unlimited).
+	MaxResponseSize *int64 `json:"max_response_size,omitempty"`
 
 	// MaxWorkers limits the number of goroutines used to process ESI tokens
 	// within a single MESIParse call. Zero means runtime.NumCPU()*4 (library default).
@@ -243,7 +243,10 @@ func (m *MesiMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next 
 			Debug:                  m.Debug,
 			MaxConcurrentRequests:  m.MaxConcurrentRequests,
 			MaxWorkers:             m.MaxWorkers,
-			MaxResponseSize:        m.MaxResponseSize,
+		}
+
+		if m.MaxResponseSize != nil {
+			config.MaxResponseSize = *m.MaxResponseSize
 		}
 
 		if m.cache != nil {
@@ -338,7 +341,7 @@ func (m *MesiMiddleware) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if err != nil {
 					return d.Errf("invalid max_response_size %q: %v", d.Val(), err)
 				}
-				m.MaxResponseSize = v
+				m.MaxResponseSize = &v
 		case "shared_http_client":
 			m.SharedHTTPClient = true
 		case "block_private_ips":

--- a/servers/caddy/mesi.go
+++ b/servers/caddy/mesi.go
@@ -98,6 +98,12 @@ type MesiMiddleware struct {
 	// to allow internal ESI includes (e.g. service meshes, metadata services).
 	BlockPrivateIPs *bool `json:"block_private_ips,omitempty"`
 
+	// MaxResponseSize limits the size (in bytes) of an individual ESI include
+	// response. Responses exceeding this limit are treated as errors and replaced
+	// with IncludeErrorMarker (or silently dropped). 0 = unlimited, but note the
+	// library default is 10 MB when this is left unset at the config level.
+	MaxResponseSize int64 `json:"max_response_size,omitempty"`
+
 	// MaxWorkers limits the number of goroutines used to process ESI tokens
 	// within a single MESIParse call. Zero means runtime.NumCPU()*4 (library default).
 	// This controls token-processing goroutines, not HTTP fetch goroutines
@@ -237,6 +243,7 @@ func (m *MesiMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next 
 			Debug:                  m.Debug,
 			MaxConcurrentRequests:  m.MaxConcurrentRequests,
 			MaxWorkers:             m.MaxWorkers,
+			MaxResponseSize:        m.MaxResponseSize,
 		}
 
 		if m.cache != nil {
@@ -314,15 +321,24 @@ func (m *MesiMiddleware) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if err != nil {
 					return d.Errf("invalid max_concurrent_requests %q: %v", d.Val(), err)
 				}
-			case "max_workers":
+		case "max_workers":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			var err error
+			m.MaxWorkers, err = strconv.Atoi(d.Val())
+			if err != nil {
+				return d.Errf("invalid max_workers %q: %v", d.Val(), err)
+			}
+			case "max_response_size":
 				if !d.NextArg() {
 					return d.ArgErr()
 				}
-				var err error
-				m.MaxWorkers, err = strconv.Atoi(d.Val())
+				v, err := strconv.ParseInt(d.Val(), 10, 64)
 				if err != nil {
-					return d.Errf("invalid max_workers %q: %v", d.Val(), err)
+					return d.Errf("invalid max_response_size %q: %v", d.Val(), err)
 				}
+				m.MaxResponseSize = v
 		case "shared_http_client":
 			m.SharedHTTPClient = true
 		case "block_private_ips":

--- a/servers/caddy/mesi_test.go
+++ b/servers/caddy/mesi_test.go
@@ -2809,3 +2809,187 @@ func TestMaxWorkersNegativeProvision(t *testing.T) {
 		t.Errorf("expected MaxWorkers=-1, got %d", m.MaxWorkers)
 	}
 }
+
+// --- MaxResponseSize Directive Tests ---
+
+// TestMaxResponseSizeDefaultUnset verifies that when max_response_size is not set,
+// MaxResponseSize is 0 (library default: 10MB).
+func TestMaxResponseSizeDefaultUnset(t *testing.T) {
+	m := &MesiMiddleware{}
+	if err := m.Provision(caddy.Context{}); err != nil {
+		t.Fatalf("Provision() returned error: %v", err)
+	}
+	if m.MaxResponseSize != 0 {
+		t.Errorf("MaxResponseSize should be 0 (library default) by default, got %d", m.MaxResponseSize)
+	}
+}
+
+// TestUnmarshalCaddyfileMaxResponseSize parses max_response_size directive with valid value.
+func TestUnmarshalCaddyfileMaxResponseSize(t *testing.T) {
+	input := `mesi {
+		max_response_size 1048576
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	m := &MesiMiddleware{}
+	err := m.UnmarshalCaddyfile(d)
+	if err != nil {
+		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
+	}
+	if m.MaxResponseSize != 1048576 {
+		t.Errorf("expected MaxResponseSize=1048576, got %d", m.MaxResponseSize)
+	}
+}
+
+// TestUnmarshalCaddyfileMaxResponseSizeZero parses max_response_size 0 (unlimited).
+func TestUnmarshalCaddyfileMaxResponseSizeZero(t *testing.T) {
+	input := `mesi {
+		max_response_size 0
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	m := &MesiMiddleware{}
+	err := m.UnmarshalCaddyfile(d)
+	if err != nil {
+		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
+	}
+	if m.MaxResponseSize != 0 {
+		t.Errorf("expected MaxResponseSize=0 (unlimited), got %d", m.MaxResponseSize)
+	}
+}
+
+// TestUnmarshalCaddyfileMaxResponseSizeNegative verifies that max_response_size
+// with a negative value is parsed (validation happens at the library level).
+func TestUnmarshalCaddyfileMaxResponseSizeNegative(t *testing.T) {
+	input := `mesi {
+		max_response_size -1
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	m := &MesiMiddleware{}
+	err := m.UnmarshalCaddyfile(d)
+	if err != nil {
+		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
+	}
+	if m.MaxResponseSize != -1 {
+		t.Errorf("expected MaxResponseSize=-1, got %d", m.MaxResponseSize)
+	}
+}
+
+// TestUnmarshalCaddyfileMaxResponseSizeInvalid verifies that max_response_size
+// with a non-numeric value returns an error.
+func TestUnmarshalCaddyfileMaxResponseSizeInvalid(t *testing.T) {
+	input := `mesi {
+		max_response_size not-a-number
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	m := &MesiMiddleware{}
+	err := m.UnmarshalCaddyfile(d)
+	if err == nil {
+		t.Fatal("UnmarshalCaddyfile should return error for invalid max_response_size")
+	}
+	if !strings.Contains(err.Error(), "invalid max_response_size") {
+		t.Errorf("expected 'invalid max_response_size' error, got: %v", err)
+	}
+}
+
+// TestUnmarshalCaddyfileMaxResponseSizeNoArg verifies that max_response_size
+// without argument returns ArgErr.
+func TestUnmarshalCaddyfileMaxResponseSizeNoArg(t *testing.T) {
+	input := `mesi {
+		max_response_size
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	m := &MesiMiddleware{}
+	err := m.UnmarshalCaddyfile(d)
+	if err == nil {
+		t.Fatal("UnmarshalCaddyfile should return error for max_response_size without argument")
+	}
+}
+
+// TestMaxResponseSizeProvision verifies that Provision works with MaxResponseSize set.
+func TestMaxResponseSizeProvision(t *testing.T) {
+	m := &MesiMiddleware{MaxResponseSize: 1048576}
+	if err := m.Provision(caddy.Context{}); err != nil {
+		t.Fatalf("Provision() returned error: %v", err)
+	}
+	if m.MaxResponseSize != 1048576 {
+		t.Errorf("expected MaxResponseSize=1048576, got %d", m.MaxResponseSize)
+	}
+}
+
+// TestMaxResponseSizeServeHTTP verifies that the configured MaxResponseSize is passed
+// to EsiParserConfig in ServeHTTP.
+func TestMaxResponseSizeServeHTTP(t *testing.T) {
+	m := &MesiMiddleware{MaxResponseSize: 2048}
+	if err := m.Provision(caddy.Context{}); err != nil {
+		t.Fatalf("Provision() returned error: %v", err)
+	}
+
+	handler := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("<html><body>max response size test</body></html>"))
+		return nil
+	})
+
+	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	rec := httptest.NewRecorder()
+
+	err := m.ServeHTTP(rec, req, handler)
+	if err != nil {
+		t.Fatalf("ServeHTTP returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", rec.Code)
+	}
+}
+
+// TestMaxResponseSizeWithOtherDirectives verifies max_response_size
+// works alongside other directives.
+func TestMaxResponseSizeWithOtherDirectives(t *testing.T) {
+	input := `mesi {
+		max_response_size 524288
+		max_depth 3
+		shared_http_client
+		timeout 15s
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	m := &MesiMiddleware{}
+	if err := m.UnmarshalCaddyfile(d); err != nil {
+		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
+	}
+	if m.MaxResponseSize != 524288 {
+		t.Errorf("expected MaxResponseSize=524288, got %d", m.MaxResponseSize)
+	}
+	if m.MaxDepth == nil || *m.MaxDepth != 3 {
+		t.Errorf("expected MaxDepth=3, got %v", m.MaxDepth)
+	}
+	if !m.SharedHTTPClient {
+		t.Error("SharedHTTPClient should be true")
+	}
+	if m.Timeout != "15s" {
+		t.Errorf("expected Timeout='15s', got '%s'", m.Timeout)
+	}
+}
+
+// TestMaxResponseSizeIntegrationParseAndProvision verifies the full flow:
+// Caddyfile parsing → Provision → Cleanup with max_response_size.
+func TestMaxResponseSizeIntegrationParseAndProvision(t *testing.T) {
+	input := `mesi {
+		max_response_size 1048576
+		max_depth 5
+		timeout 10s
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	m := &MesiMiddleware{}
+	if err := m.UnmarshalCaddyfile(d); err != nil {
+		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
+	}
+	if m.MaxResponseSize != 1048576 {
+		t.Errorf("expected MaxResponseSize=1048576, got %d", m.MaxResponseSize)
+	}
+	if err := m.Provision(caddy.Context{}); err != nil {
+		t.Fatalf("Provision() returned error: %v", err)
+	}
+	if err := m.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() returned error: %v", err)
+	}
+}

--- a/servers/caddy/mesi_test.go
+++ b/servers/caddy/mesi_test.go
@@ -2813,14 +2813,14 @@ func TestMaxWorkersNegativeProvision(t *testing.T) {
 // --- MaxResponseSize Directive Tests ---
 
 // TestMaxResponseSizeDefaultUnset verifies that when max_response_size is not set,
-// MaxResponseSize is 0 (library default: 10MB).
+// MaxResponseSize is nil and the library default (10 MB) is used.
 func TestMaxResponseSizeDefaultUnset(t *testing.T) {
 	m := &MesiMiddleware{}
 	if err := m.Provision(caddy.Context{}); err != nil {
 		t.Fatalf("Provision() returned error: %v", err)
 	}
-	if m.MaxResponseSize != 0 {
-		t.Errorf("MaxResponseSize should be 0 (library default) by default, got %d", m.MaxResponseSize)
+	if m.MaxResponseSize != nil {
+		t.Errorf("MaxResponseSize should be nil by default, got %v", *m.MaxResponseSize)
 	}
 }
 
@@ -2835,8 +2835,11 @@ func TestUnmarshalCaddyfileMaxResponseSize(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
 	}
-	if m.MaxResponseSize != 1048576 {
-		t.Errorf("expected MaxResponseSize=1048576, got %d", m.MaxResponseSize)
+	if m.MaxResponseSize == nil {
+		t.Fatal("MaxResponseSize should be non-nil after parsing max_response_size 1048576")
+	}
+	if *m.MaxResponseSize != 1048576 {
+		t.Errorf("expected MaxResponseSize=1048576, got %d", *m.MaxResponseSize)
 	}
 }
 
@@ -2851,8 +2854,11 @@ func TestUnmarshalCaddyfileMaxResponseSizeZero(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
 	}
-	if m.MaxResponseSize != 0 {
-		t.Errorf("expected MaxResponseSize=0 (unlimited), got %d", m.MaxResponseSize)
+	if m.MaxResponseSize == nil {
+		t.Fatal("MaxResponseSize should be non-nil after parsing max_response_size 0")
+	}
+	if *m.MaxResponseSize != 0 {
+		t.Errorf("expected MaxResponseSize=0 (unlimited), got %d", *m.MaxResponseSize)
 	}
 }
 
@@ -2868,8 +2874,11 @@ func TestUnmarshalCaddyfileMaxResponseSizeNegative(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
 	}
-	if m.MaxResponseSize != -1 {
-		t.Errorf("expected MaxResponseSize=-1, got %d", m.MaxResponseSize)
+	if m.MaxResponseSize == nil {
+		t.Fatal("MaxResponseSize should be non-nil after parsing max_response_size -1")
+	}
+	if *m.MaxResponseSize != -1 {
+		t.Errorf("expected MaxResponseSize=-1, got %d", *m.MaxResponseSize)
 	}
 }
 
@@ -2906,19 +2915,21 @@ func TestUnmarshalCaddyfileMaxResponseSizeNoArg(t *testing.T) {
 
 // TestMaxResponseSizeProvision verifies that Provision works with MaxResponseSize set.
 func TestMaxResponseSizeProvision(t *testing.T) {
-	m := &MesiMiddleware{MaxResponseSize: 1048576}
+	v := int64(1048576)
+	m := &MesiMiddleware{MaxResponseSize: &v}
 	if err := m.Provision(caddy.Context{}); err != nil {
 		t.Fatalf("Provision() returned error: %v", err)
 	}
-	if m.MaxResponseSize != 1048576 {
-		t.Errorf("expected MaxResponseSize=1048576, got %d", m.MaxResponseSize)
+	if m.MaxResponseSize == nil || *m.MaxResponseSize != 1048576 {
+		t.Errorf("expected MaxResponseSize=1048576, got %v", m.MaxResponseSize)
 	}
 }
 
 // TestMaxResponseSizeServeHTTP verifies that the configured MaxResponseSize is passed
 // to EsiParserConfig in ServeHTTP.
 func TestMaxResponseSizeServeHTTP(t *testing.T) {
-	m := &MesiMiddleware{MaxResponseSize: 2048}
+	v := int64(2048)
+	m := &MesiMiddleware{MaxResponseSize: &v}
 	if err := m.Provision(caddy.Context{}); err != nil {
 		t.Fatalf("Provision() returned error: %v", err)
 	}
@@ -2956,8 +2967,8 @@ func TestMaxResponseSizeWithOtherDirectives(t *testing.T) {
 	if err := m.UnmarshalCaddyfile(d); err != nil {
 		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
 	}
-	if m.MaxResponseSize != 524288 {
-		t.Errorf("expected MaxResponseSize=524288, got %d", m.MaxResponseSize)
+	if m.MaxResponseSize == nil || *m.MaxResponseSize != 524288 {
+		t.Errorf("expected MaxResponseSize=524288, got %v", m.MaxResponseSize)
 	}
 	if m.MaxDepth == nil || *m.MaxDepth != 3 {
 		t.Errorf("expected MaxDepth=3, got %v", m.MaxDepth)
@@ -2983,8 +2994,8 @@ func TestMaxResponseSizeIntegrationParseAndProvision(t *testing.T) {
 	if err := m.UnmarshalCaddyfile(d); err != nil {
 		t.Fatalf("UnmarshalCaddyfile returned error: %v", err)
 	}
-	if m.MaxResponseSize != 1048576 {
-		t.Errorf("expected MaxResponseSize=1048576, got %d", m.MaxResponseSize)
+	if m.MaxResponseSize == nil || *m.MaxResponseSize != 1048576 {
+		t.Errorf("expected MaxResponseSize=1048576, got %v", m.MaxResponseSize)
 	}
 	if err := m.Provision(caddy.Context{}); err != nil {
 		t.Fatalf("Provision() returned error: %v", err)


### PR DESCRIPTION
## Summary

Adds the  Caddyfile directive to limit individual ESI include response sizes. This is a security directive that prevents a malicious or misconfigured backend from returning unbounded responses that could exhaust memory.

## Changes

- Added  field to  struct
- Added  directive parsing in 
- Pass  to  in 
- Added 10 unit tests covering parsing, validation, and integration
- Updated README with directive documentation

## Caddyfile Usage

```
mesi {
    max_response_size 1048576   # 1 MB
}
```

| Value | Behaviour |
|---|---|
| `1–N` | Include responses larger than N bytes are rejected. |
| `0` | Unlimited (no size check). |
| absent | Library default: `10485760` (10 MB). |

## Tests

All 10 new tests pass:
- `TestUnmarshalCaddyfileMaxResponseSize` — valid value parsing
- `TestUnmarshalCaddyfileMaxResponseSizeZero` — zero (unlimited)
- `TestUnmarshalCaddyfileMaxResponseSizeNegative` — negative value
- `TestUnmarshalCaddyfileMaxResponseSizeInvalid` — non-numeric error
- `TestUnmarshalCaddyfileMaxResponseSizeNoArg` — missing argument error
- `TestMaxResponseSizeDefaultUnset` — default when absent
- `TestMaxResponseSizeProvision` — Provision with value set
- `TestMaxResponseSizeServeHTTP` — ServeHTTP with value set
- `TestMaxResponseSizeWithOtherDirectives` — works alongside other directives
- `TestMaxResponseSizeIntegrationParseAndProvision` — full flow

Closes #257