### PR TITLE
feat(frankenphp): add integration tests and CI job

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -258,9 +258,31 @@ jobs:
         if: always()
         run: cd servers/caddy && docker compose down -v 2>/dev/null || true
 
+  frankenphp-test:
+    name: FrankenPHP Integration Test
+    runs-on: ubuntu-latest
+    needs: test
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+
+      - name: Run FrankenPHP tests
+        run: cd servers/frankenphp && ./test.sh
+
+      - name: Cleanup
+        if: always()
+        run: cd servers/frankenphp && docker compose down -v 2>/dev/null || true
+
   ci:
     name: CI
-    needs: [lint, test, apache-test, traefik-test, nginx-test, caddy-test, proxy-test, cli-test, cli-e2e-test]
+    needs: [lint, test, apache-test, traefik-test, nginx-test, caddy-test, frankenphp-test, proxy-test, cli-test, cli-e2e-test]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -272,6 +294,7 @@ jobs:
           if [ "${{ needs.traefik-test.result }}" != "success" ]; then exit 1; fi
           if [ "${{ needs.nginx-test.result }}" != "success" ]; then exit 1; fi
           if [ "${{ needs.caddy-test.result }}" != "success" ]; then exit 1; fi
+          if [ "${{ needs.frankenphp-test.result }}" != "success" ]; then exit 1; fi
           if [ "${{ needs.proxy-test.result }}" != "success" ]; then exit 1; fi
           if [ "${{ needs.cli-test.result }}" != "success" ]; then exit 1; fi
           if [ "${{ needs.cli-e2e-test.result }}" != "success" ]; then exit 1; fi

--- a/servers/frankenphp/Caddyfile.ci
+++ b/servers/frankenphp/Caddyfile.ci
@@ -1,13 +1,21 @@
 {
     admin off
     frankenphp
-    order mesi before php_server
 }
 
 :8080 {
-    root * /app
-    mesi {
-        block_private_ips false
+    route {
+        mesi {
+            block_private_ips false
+        }
+
+        @backend path /proxy*
+        handle @backend {
+            uri strip_prefix /proxy
+            reverse_proxy test-server:80
+        }
+
+        root * /app
+        php_server
     }
-    php_server
 }

--- a/servers/frankenphp/Caddyfile.ci
+++ b/servers/frankenphp/Caddyfile.ci
@@ -1,0 +1,13 @@
+{
+    admin off
+    frankenphp
+    order mesi before php_server
+}
+
+:8080 {
+    root * /app
+    mesi {
+        block_private_ips false
+    }
+    php_server
+}

--- a/servers/frankenphp/Dockerfile
+++ b/servers/frankenphp/Dockerfile
@@ -1,6 +1,7 @@
-FROM php:8.3-cli-bookworm AS build
+FROM dunglas/frankenphp:latest AS build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
     git \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*

--- a/servers/frankenphp/Dockerfile
+++ b/servers/frankenphp/Dockerfile
@@ -4,7 +4,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git \
     ca-certificates \
+    php8.3-dev \
     && rm -rf /var/lib/apt/lists/*
+
+RUN PHP_INCLUDE_DIR=$(php-config --include-dir) && \
+    echo "PHP include dir: $PHP_INCLUDE_DIR" && \
+    ls -la "$PHP_INCLUDE_DIR" && \
+    if [ ! -d /usr/local/include/php ]; then \
+        ln -sf "$PHP_INCLUDE_DIR" /usr/local/include/php; \
+    fi
 
 RUN curl -fsSL https://go.dev/dl/go1.23.5.linux-amd64.tar.gz | tar -C /usr/local -xz
 

--- a/servers/frankenphp/Dockerfile
+++ b/servers/frankenphp/Dockerfile
@@ -1,0 +1,33 @@
+FROM php:8.3-cli-bookworm AS build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://go.dev/dl/go1.26.0.linux-amd64.tar.gz | tar -C /usr/local -xz
+
+ENV PATH=$PATH:/usr/local/go/bin:/root/go/bin
+
+RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+
+WORKDIR /build
+
+COPY . /build/go-mesi
+
+WORKDIR /build/go-mesi
+
+RUN CGO_ENABLED=1 \
+    xcaddy build \
+        --output /usr/local/bin/frankenphp \
+        --with github.com/dunglas/frankenphp \
+        --with github.com/crazy-goat/go-mesi/servers/caddy=./servers/caddy
+
+FROM dunglas/frankenphp:latest
+
+COPY --from=build /usr/local/bin/frankenphp /usr/local/bin/frankenphp
+
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/frankenphp"]
+CMD ["run", "--config", "/etc/caddy/Caddyfile"]

--- a/servers/frankenphp/Dockerfile
+++ b/servers/frankenphp/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://go.dev/dl/go1.22.5.linux-amd64.tar.gz | tar -C /usr/local -xz
+RUN curl -fsSL https://go.dev/dl/go1.23.5.linux-amd64.tar.gz | tar -C /usr/local -xz
 
 ENV PATH=$PATH:/usr/local/go/bin:/root/go/bin
 

--- a/servers/frankenphp/Dockerfile
+++ b/servers/frankenphp/Dockerfile
@@ -18,6 +18,8 @@ COPY . /build/go-mesi
 
 WORKDIR /build/go-mesi
 
+ENV XCADDY_GO_BUILD_FLAGS="-tags=nobadger,nomysql,nopgx,nowatcher"
+
 RUN CGO_ENABLED=1 \
     xcaddy build \
         --output /usr/local/bin/frankenphp \

--- a/servers/frankenphp/Dockerfile
+++ b/servers/frankenphp/Dockerfile
@@ -1,22 +1,15 @@
-FROM php:8.3-zts-bookworm AS build
+FROM php:8.3-zts-bookworm AS php
+
+FROM golang:1.26-bookworm AS build
+
+COPY --from=php /usr/local /usr/local
+
+RUN ldconfig
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
     git \
     ca-certificates \
-    php8.3-dev \
     && rm -rf /var/lib/apt/lists/*
-
-RUN PHP_INCLUDE_DIR=$(php-config --include-dir) && \
-    echo "PHP include dir: $PHP_INCLUDE_DIR" && \
-    ls -la "$PHP_INCLUDE_DIR" && \
-    if [ ! -d /usr/local/include/php ]; then \
-        ln -sf "$PHP_INCLUDE_DIR" /usr/local/include/php; \
-    fi
-
-RUN curl -fsSL https://go.dev/dl/go1.23.5.linux-amd64.tar.gz | tar -C /usr/local -xz
-
-ENV PATH=$PATH:/usr/local/go/bin:/root/go/bin
 
 RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
 

--- a/servers/frankenphp/Dockerfile
+++ b/servers/frankenphp/Dockerfile
@@ -22,7 +22,8 @@ RUN CGO_ENABLED=1 \
     xcaddy build \
         --output /usr/local/bin/frankenphp \
         --with github.com/dunglas/frankenphp \
-        --with github.com/crazy-goat/go-mesi/servers/caddy=./servers/caddy
+        --with github.com/crazy-goat/go-mesi/servers/caddy=./servers/caddy \
+        --with github.com/crazy-goat/go-mesi=.
 
 FROM dunglas/frankenphp:latest
 

--- a/servers/frankenphp/Dockerfile
+++ b/servers/frankenphp/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://go.dev/dl/go1.26.0.linux-amd64.tar.gz | tar -C /usr/local -xz
+RUN curl -fsSL https://go.dev/dl/go1.22.5.linux-amd64.tar.gz | tar -C /usr/local -xz
 
 ENV PATH=$PATH:/usr/local/go/bin:/root/go/bin
 

--- a/servers/frankenphp/Dockerfile
+++ b/servers/frankenphp/Dockerfile
@@ -1,4 +1,4 @@
-FROM dunglas/frankenphp:latest AS build
+FROM php:8.3-zts-bookworm AS build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \

--- a/servers/frankenphp/Dockerfile
+++ b/servers/frankenphp/Dockerfile
@@ -9,6 +9,15 @@ RUN ldconfig
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     ca-certificates \
+    libxml2-dev \
+    libssl-dev \
+    libsqlite3-dev \
+    libcurl4-openssl-dev \
+    libonig-dev \
+    libreadline-dev \
+    libncurses-dev \
+    libargon2-dev \
+    zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
@@ -22,13 +31,16 @@ WORKDIR /build/go-mesi
 ENV XCADDY_GO_BUILD_FLAGS="-tags=nobadger,nomysql,nopgx,nowatcher"
 
 RUN CGO_ENABLED=1 \
+    CGO_CFLAGS="$(php-config --includes)" \
+    CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" \
     xcaddy build \
         --output /usr/local/bin/frankenphp \
         --with github.com/dunglas/frankenphp \
+        --with github.com/dunglas/frankenphp/caddy \
         --with github.com/crazy-goat/go-mesi/servers/caddy=./servers/caddy \
         --with github.com/crazy-goat/go-mesi=.
 
-FROM dunglas/frankenphp:latest
+FROM dunglas/frankenphp:1-php8.3
 
 COPY --from=build /usr/local/bin/frankenphp /usr/local/bin/frankenphp
 

--- a/servers/frankenphp/Makefile
+++ b/servers/frankenphp/Makefile
@@ -10,3 +10,8 @@ build:
 
 run: build
 	./frankenphp run --config Caddyfile
+
+test: ## Run integration tests
+	./test.sh
+
+.PHONY: build run test

--- a/servers/frankenphp/README.md
+++ b/servers/frankenphp/README.md
@@ -54,3 +54,22 @@ Finally, you can start the FrankenPHP server with the command:
 ```shell
 frankenphp run --config Caddyfile
 ```
+
+## Testing
+
+Integration tests verify ESI processing for both static HTML and PHP-generated content:
+
+```shell
+make test
+```
+
+This uses `docker compose` to build a FrankenPHP image with the mesi module, starts a test backend server, and runs curl-based tests against the following scenarios:
+
+- Module loaded: `http.handlers.mesi` registered
+- ESI include in static HTML and PHP-generated HTML
+- ESI comment unwrapping (`<!--esi ... -->`)
+- ESI remove (`<esi:remove>`)
+- Surrogate-Capability header presence
+- Non-HTML content bypass (text/plain, application/json)
+- Content-Length correctness
+- Content-Type preservation

--- a/servers/frankenphp/docker-compose.yml
+++ b/servers/frankenphp/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  frankenphp:
+    build:
+      context: ../..
+      dockerfile: servers/frankenphp/Dockerfile
+    volumes:
+      - ./Caddyfile.ci:/etc/caddy/Caddyfile
+      - ./tests:/app
+    ports:
+      - 8080:8080
+    depends_on:
+      test-server:
+        condition: service_started
+
+  test-server:
+    build:
+      context: ../test-server
+      dockerfile: Dockerfile

--- a/servers/frankenphp/test.sh
+++ b/servers/frankenphp/test.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+docker compose up -d --build
+
+echo "Waiting for FrankenPHP to be ready..."
+for i in $(seq 1 60); do
+    if curl -s -o /dev/null http://localhost:8080/index.html 2>/dev/null; then
+        echo "FrankenPHP ready after ${i}s"
+        break
+    fi
+    if [ "$i" -eq 60 ]; then
+        echo "FAIL: FrankenPHP did not become ready within 60s"
+        docker compose logs
+        docker compose down
+        exit 1
+    fi
+    sleep 2
+done
+
+echo "=== Test 1: Module loaded ==="
+MODULES=$(docker compose exec frankenphp frankenphp list-modules 2>&1)
+if echo "$MODULES" | grep -q "http.handlers.mesi"; then
+    echo "PASS: http.handlers.mesi module loaded"
+else
+    echo "FAIL: mesi module not found"
+    echo "Modules: $MODULES"
+    docker compose down
+    exit 1
+fi
+
+echo "=== Test 2: ESI include in static HTML ==="
+RESPONSE=$(curl -s http://localhost:8080/index.html)
+if echo "$RESPONSE" | grep -q "Hurray: Esi included!"; then
+    echo "PASS: ESI include processed correctly in static HTML"
+else
+    echo "FAIL: ESI include not processed in static HTML"
+    echo "Response: $RESPONSE"
+    docker compose down
+    exit 1
+fi
+
+echo "=== Test 3: ESI include in PHP-generated HTML ==="
+RESPONSE=$(curl -s http://localhost:8080/esi.php)
+if echo "$RESPONSE" | grep -q "Hurray: Esi included!"; then
+    echo "PASS: ESI include processed correctly in PHP-generated HTML"
+else
+    echo "FAIL: ESI include not processed in PHP-generated HTML"
+    echo "Response: $RESPONSE"
+    docker compose down
+    exit 1
+fi
+
+echo "=== Test 4: ESI comment unwrapping ==="
+RESPONSE=$(curl -s http://localhost:8080/index.html)
+if echo "$RESPONSE" | grep -q "Unwrapped content"; then
+    echo "PASS: ESI comment unwrapped correctly"
+else
+    echo "FAIL: ESI comment not unwrapped"
+    echo "Response: $RESPONSE"
+    docker compose down
+    exit 1
+fi
+
+echo "=== Test 5: ESI remove ==="
+RESPONSE=$(curl -s http://localhost:8080/index.html)
+if echo "$RESPONSE" | grep -q "Failed to include ESI"; then
+    echo "FAIL: ESI remove content still present"
+    echo "Response: $RESPONSE"
+    docker compose down
+    exit 1
+else
+    echo "PASS: ESI remove processed correctly"
+fi
+
+echo "=== Test 6: Surrogate-Capability header ==="
+HEADERS=$(curl -sI http://localhost:8080/index.html)
+if echo "$HEADERS" | grep -q "Surrogate-Capability"; then
+    echo "PASS: Surrogate-Capability header present"
+else
+    echo "FAIL: Surrogate-Capability header missing"
+    echo "Headers: $HEADERS"
+    docker compose down
+    exit 1
+fi
+
+echo "=== Test 7: Non-HTML content bypass (PHP-generated) ==="
+RESPONSE=$(curl -s http://localhost:8080/plain.php)
+if echo "$RESPONSE" | grep -q "esi:include"; then
+    echo "PASS: text/plain content bypassed ESI filter (tags preserved verbatim)"
+else
+    echo "FAIL: text/plain content was processed"
+    echo "Response: $RESPONSE"
+    docker compose down
+    exit 1
+fi
+
+echo "=== Test 8: Content-Length correctness ==="
+HEADERS=$(curl -sD - http://localhost:8080/index.html -o /tmp/mesi-frankenphp-response.txt 2>/dev/null)
+ACTUAL_BODY_SIZE=$(wc -c < /tmp/mesi-frankenphp-response.txt)
+HEADER_CL=$(echo "$HEADERS" | grep -i "Content-Length" | awk '{print $2}' | tr -d '\r')
+if [ -n "$HEADER_CL" ]; then
+    if [ "$HEADER_CL" -eq "$ACTUAL_BODY_SIZE" ] 2>/dev/null; then
+        echo "PASS: Content-Length ($HEADER_CL) matches actual body size ($ACTUAL_BODY_SIZE)"
+    else
+        echo "FAIL: Content-Length ($HEADER_CL) != body size ($ACTUAL_BODY_SIZE)"
+        docker compose down
+        exit 1
+    fi
+else
+    echo "PASS: Content-Length correctly absent (truncated after ESI processing)"
+fi
+rm -f /tmp/mesi-frankenphp-response.txt
+
+echo "=== Test 9: Content-Type preserved ==="
+CT_HEADERS=$(curl -sI http://localhost:8080/esi.php)
+if echo "$CT_HEADERS" | grep -qi "text/html"; then
+    echo "PASS: Content-Type is text/html for PHP-generated HTML"
+else
+    echo "FAIL: Content-Type missing or wrong for PHP-generated HTML"
+    echo "Content-Type: $CT_HEADERS"
+    docker compose down
+    exit 1
+fi
+
+echo "=== Test 10: Non-HTML JSON response preserved ==="
+RESPONSE=$(curl -s http://localhost:8080/esi-non-html.php)
+if echo "$RESPONSE" | grep -q "esi:include"; then
+    echo "PASS: JSON content bypassed ESI filter (tags preserved verbatim)"
+else
+    echo "FAIL: JSON content was processed"
+    echo "Response: $RESPONSE"
+    docker compose down
+    exit 1
+fi
+
+docker compose down
+
+echo ""
+echo "=== All FrankenPHP tests passed ==="

--- a/servers/frankenphp/test.sh
+++ b/servers/frankenphp/test.sh
@@ -77,7 +77,7 @@ else
 fi
 
 echo "=== Test 6: Surrogate-Capability header ==="
-HEADERS=$(curl -sI http://localhost:8080/index.html)
+HEADERS=$(curl -sI http://localhost:8080/proxy/)
 if echo "$HEADERS" | grep -q "Surrogate-Capability"; then
     echo "PASS: Surrogate-Capability header present"
 else

--- a/servers/frankenphp/tests/esi-non-html.php
+++ b/servers/frankenphp/tests/esi-non-html.php
@@ -1,0 +1,6 @@
+<?php
+header('Content-Type: application/json');
+echo json_encode([
+    'message' => 'ESI test',
+    'content' => '<esi:include src="http://test-server/esi" />'
+]);

--- a/servers/frankenphp/tests/esi.php
+++ b/servers/frankenphp/tests/esi.php
@@ -1,0 +1,15 @@
+<?php
+header('Content-Type: text/html');
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>ESI PHP Test</title>
+</head>
+<body>
+<h1>Welcome to ESI PHP Test</h1>
+<esi:include src="http://test-server/esi" />
+<esi:remove>Failed to include ESI from PHP</esi:remove>
+<!--esi <p>PHP unwrapped content</p> -->
+</body>
+</html>

--- a/servers/frankenphp/tests/index.html
+++ b/servers/frankenphp/tests/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>ESI Static Test</title>
+</head>
+<body>
+<h1>Welcome to ESI Test</h1>
+<esi:include src="http://test-server/esi" />
+<esi:remove>Failed to include ESI</esi:remove>
+<!--esi <p>Unwrapped content</p> -->
+</body>
+</html>

--- a/servers/frankenphp/tests/plain.php
+++ b/servers/frankenphp/tests/plain.php
@@ -1,0 +1,4 @@
+<?php
+header('Content-Type: text/plain');
+?>
+plain text with <esi:include src="http://test-server/esi" /> tags


### PR DESCRIPTION
Closes #83

## Summary
Add end-to-end integration tests and GitHub Actions CI job for the FrankenPHP ESI integration (`servers/frankenphp/`).

## Changes
- **Dockerfile**: Multi-stage build using `php:8.3-cli-bookworm` (PHP dev headers) + manual Go install, builds FrankenPHP binary with mesi module via xcaddy
- **docker-compose.yml**: FrankenPHP service + test-server backend for ESI includes
- **Caddyfile.ci**: CI configuration with `frankenphp` directive, `mesi` middleware, and `php_server`
- **test.sh**: 10 test cases covering:\n  - Module loaded check\n  - ESI include in static HTML\n  - ESI include in PHP-generated HTML\n  - ESI comment unwrapping\n  - ESI remove\n  - Surrogate-Capability header\n  - Non-HTML content bypass (text/plain)\n  - Content-Length correctness\n  - Content-Type preservation\n  - Non-HTML JSON response preserved
- **PHP test fixtures**: Static HTML, PHP-generated HTML, plain text, JSON files
- **Makefile**: Added `test` target
- **CI workflow**: Added `frankenphp-test` job (15min timeout), included in `ci` gate

## Key difference from Caddy tests
FrankenPHP is the only integration that tests ESI processing of **dynamically generated PHP content**, validating the mesi middleware works with server-side rendered HTML.