### PR TITLE
docs(changelog): add entries for all 0.8.0 milestone issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,11 @@
 ## [0.8.0] - Unreleased
 
 ### Added
-- RoadRunner integration tests: Dockerfile, docker-compose, Makefile, test.sh, and CI job
+- Traefik integration tests: docker-compose, test.sh, and CI job (#79, #302)
+- RoadRunner integration tests: Dockerfile, docker-compose, Makefile, test.sh, and CI job (#80, #306)
+- Nginx integration tests: Dockerfile, docker-compose, test.sh, and CI job (#81, #300)
+- Caddy integration tests: docker-compose, test.sh, and CI job (#82, #301)
+- FrankenPHP integration tests: Dockerfile, docker-compose, Caddyfile.ci, test.sh, PHP fixtures, and CI job (#83, #304)
+- Standalone proxy tests: Go unit tests, E2E test.sh, and CI job (#84, #271)
+- PHP extension test suite: `.phpt` tests, Dockerfile, docker-compose, test.sh, and CI job (#85, #305)
+- CLI tests: Go unit tests, E2E test.sh, and separate unit/E2E CI jobs (#86, #272)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Traefik integration tests: docker-compose, test.sh, and CI job (#79, #302)
 - RoadRunner integration tests: Dockerfile, docker-compose, Makefile, test.sh, and CI job (#80, #306)
 - Nginx integration tests: Dockerfile, docker-compose, test.sh, and CI job (#81, #300)
-- Caddy integration tests: docker-compose, test.sh, and CI job (#82, #301)
+- Caddy integration tests: Dockerfile, docker-compose, Caddyfile.test, test.sh, and CI job (#82, #301)
 - FrankenPHP integration tests: Dockerfile, docker-compose, Caddyfile.ci, test.sh, PHP fixtures, and CI job (#83, #304)
 - Standalone proxy tests: Go unit tests, E2E test.sh, and CI job (#84, #271)
 - PHP extension test suite: `.phpt` tests, Dockerfile, docker-compose, test.sh, and CI job (#85, #305)


### PR DESCRIPTION
## Summary

Milestone **0.8.0 - CI/CD pipeline** is feature-complete: all 8 integration test suites have been merged and the milestone shows 0 open / 11 closed items. However, `CHANGELOG.md` only listed the RoadRunner work.

This PR backfills the changelog with one bullet per delivered integration suite so the 0.8.0 release notes reflect what actually shipped.

## Changes

Added 7 missing bullets under `## [0.8.0] - Unreleased`, ordered by issue number:

| Issue | PR    | Suite           |
|-------|-------|-----------------|
| #79   | #302  | Traefik         |
| #80   | #306  | RoadRunner (already present, re-ordered) |
| #81   | #300  | Nginx           |
| #82   | #301  | Caddy           |
| #83   | #304  | FrankenPHP      |
| #84   | #271  | Standalone proxy |
| #85   | #305  | PHP extension   |
| #86   | #272  | CLI             |

Each entry follows the existing style (`<server> integration tests: <artifacts>, and CI job (<issue>, <PR>)`) and links to both the closed issue and the merging PR for traceability.

## Verification

- [x] All 8 closed issues in milestone 0.8.0 have a corresponding line
- [x] All referenced PRs (#271, #272, #300, #301, #302, #304, #305, #306) are merged
- [x] All referenced CI jobs exist in `.github/workflows/tests.yaml` (`traefik-test`, `roadrunner-test`, `nginx-test`, `caddy-test`, `frankenphp-test`, `proxy-test`, `php-ext-test`, `cli-test` + `cli-e2e-test`)
- [x] Docs-only change \u2014 no code or test impact

## Notes

- Pure docs change; no functional code touched, so existing CI jobs are sufficient gate.
- Milestone left as `Unreleased` until the maintainer cuts the tag.