### PR TITLE
feat(cli): add -cacheBackend memory flag for in-memory ESI caching (#207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.9.0] - Unreleased
+
+### Added
+- CLI memory cache backend: `-cacheBackend=memory`, `-cacheSize`, and `-cacheTTL` flags wire the `mesi.MemoryCache` into CLI invocations so duplicate `<esi:include>` URLs are served from cache within a single run (#207)
+
 ## [0.8.0] - Unreleased
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [0.9.0] - Unreleased
 
 ### Added
-- CLI memory cache backend: `-cacheBackend=memory`, `-cacheSize`, and `-cacheTTL` flags wire the `mesi.MemoryCache` into CLI invocations so duplicate `<esi:include>` URLs are served from cache within a single run (#207)
+- CLI memory cache backend: `-cache-backend=memory`, `-cache-size`, and `-cache-ttl` flags wire the `mesi.MemoryCache` into CLI invocations so duplicate `<esi:include>` URLs are served from cache within a single run (#207)
 
 ## [0.8.0] - Unreleased
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -50,6 +50,21 @@ mesi-cli [options] path/url
 - **max-depth <depth>** (integer): Defines the maximum depth of parsing, which can limit how many nested ESI includes or references are processed. Default: 5
 - **timeout <seconds>** (float): Sets the request timeout duration (in seconds) for all retrieval operations. Default: 10.0
 - **parse-on-header** (bool): Enables ESI parsing on the HTTP headers, if set to `true` response must have `Edge-control: dca=esi` to enable parsing. Default: false
+- **cacheBackend <name>** (string): Cache backend for ESI includes. Currently only `memory` is supported (in-process LRU). Default: off (no caching)
+- **cacheSize <entries>** (int): Max cache entries for the memory backend. Default: 10000
+- **cacheTTL <duration>** (duration): Cache TTL (e.g. `30s`, `5m`); `0` = no expiry. Default: 0
+- **max-workers <count>** (int): Max concurrent ESI include goroutines. `0` = `NumCPU*4`. Useful for forcing sequential processing to make caching deterministic. Default: 0
+- **allow-private-ips** (bool): Allow ESI includes to private/reserved IP ranges. Required when testing against a local ESI origin. Default: false
+
+### Caching
+
+The CLI exposes the in-memory cache from the `mesi` package. Repeated `<esi:include>` URLs within a single invocation are served from the cache instead of hitting the origin again.
+
+```shell
+mesi-cli -cacheBackend=memory -cacheSize=5000 -cacheTTL=60s ./input.html
+```
+
+The cache is **per-invocation** — it lives for the duration of a single `mesi-cli` run. For persistent or cross-process caching, run multiple inputs through the same invocation or use one of the server integrations (Traefik, Caddy, etc.) that supports Redis or Memcached.
 
 ## Example Usage
 Render an ESI-enabled HTML from a file:

--- a/cli/README.md
+++ b/cli/README.md
@@ -50,9 +50,9 @@ mesi-cli [options] path/url
 - **max-depth <depth>** (integer): Defines the maximum depth of parsing, which can limit how many nested ESI includes or references are processed. Default: 5
 - **timeout <seconds>** (float): Sets the request timeout duration (in seconds) for all retrieval operations. Default: 10.0
 - **parse-on-header** (bool): Enables ESI parsing on the HTTP headers, if set to `true` response must have `Edge-control: dca=esi` to enable parsing. Default: false
-- **cacheBackend <name>** (string): Cache backend for ESI includes. Currently only `memory` is supported (in-process LRU). Default: off (no caching)
-- **cacheSize <entries>** (int): Max cache entries for the memory backend. Default: 10000
-- **cacheTTL <duration>** (duration): Cache TTL (e.g. `30s`, `5m`); `0` = no expiry. Default: 0
+- **cache-backend <name>** (string): Cache backend for ESI includes. Currently only `memory` is supported (in-process LRU). Default: off (no caching)
+- **cache-size <entries>** (int): Max cache entries for the memory backend. Default: 10000
+- **cache-ttl <duration>** (duration): Cache TTL (e.g. `30s`, `5m`); `0` = no expiry. Default: 0
 - **max-workers <count>** (int): Max concurrent ESI include goroutines. `0` = `NumCPU*4`. Useful for forcing sequential processing to make caching deterministic. Default: 0
 - **allow-private-ips** (bool): Allow ESI includes to private/reserved IP ranges. Required when testing against a local ESI origin. Default: false
 
@@ -61,7 +61,7 @@ mesi-cli [options] path/url
 The CLI exposes the in-memory cache from the `mesi` package. Repeated `<esi:include>` URLs within a single invocation are served from the cache instead of hitting the origin again.
 
 ```shell
-mesi-cli -cacheBackend=memory -cacheSize=5000 -cacheTTL=60s ./input.html
+mesi-cli -cache-backend=memory -cache-size=5000 -cache-ttl=60s ./input.html
 ```
 
 The cache is **per-invocation** — it lives for the duration of a single `mesi-cli` run. For persistent or cross-process caching, run multiple inputs through the same invocation or use one of the server integrations (Traefik, Caddy, etc.) that supports Redis or Memcached.

--- a/cli/mesi-cli.go
+++ b/cli/mesi-cli.go
@@ -23,11 +23,11 @@ func main() {
 	timeout := flag.Float64("timeout", 10.0, "Request timeout duration in seconds")
 	parseOnHeader := flag.Bool("parse-on-header", false, "Enable parsing on header")
 	debug := flag.Bool("debug", false, "Enable debug logging")
-	cacheBackend := flag.String("cacheBackend", "",
+	cacheBackend := flag.String("cache-backend", "",
 		"Cache backend for ESI includes: memory (default: off)")
-	cacheSize := flag.Int("cacheSize", 10000,
+	cacheSize := flag.Int("cache-size", 10000,
 		"Max cache entries for memory backend")
-	cacheTTL := flag.Duration("cacheTTL", 0,
+	cacheTTL := flag.Duration("cache-ttl", 0,
 		"Cache TTL (e.g. 30s, 5m); 0 = no expiry")
 	allowPrivateIPs := flag.Bool("allow-private-ips", false,
 		"Allow ESI includes to private/reserved IP ranges (for local testing)")

--- a/cli/mesi-cli.go
+++ b/cli/mesi-cli.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/crazy-goat/go-mesi/mesi"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -22,6 +23,16 @@ func main() {
 	timeout := flag.Float64("timeout", 10.0, "Request timeout duration in seconds")
 	parseOnHeader := flag.Bool("parse-on-header", false, "Enable parsing on header")
 	debug := flag.Bool("debug", false, "Enable debug logging")
+	cacheBackend := flag.String("cacheBackend", "",
+		"Cache backend for ESI includes: memory (default: off)")
+	cacheSize := flag.Int("cacheSize", 10000,
+		"Max cache entries for memory backend")
+	cacheTTL := flag.Duration("cacheTTL", 0,
+		"Cache TTL (e.g. 30s, 5m); 0 = no expiry")
+	allowPrivateIPs := flag.Bool("allow-private-ips", false,
+		"Allow ESI includes to private/reserved IP ranges (for local testing)")
+	maxWorkers := flag.Int("max-workers", 0,
+		"Max concurrent ESI include goroutines (0 = NumCPU*4)")
 
 	flag.Parse()
 	args := flag.Args()
@@ -38,6 +49,17 @@ func main() {
 	config.Timeout = time.Duration(*timeout * float64(time.Second))
 	config.ParseOnHeader = *parseOnHeader
 	config.Debug = *debug
+	config.BlockPrivateIPs = !*allowPrivateIPs
+	config.MaxWorkers = *maxWorkers
+
+	switch *cacheBackend {
+	case "":
+	case "memory":
+		config.Cache = mesi.NewMemoryCache(*cacheSize, *cacheTTL)
+		config.CacheTTL = *cacheTTL
+	default:
+		log.Fatalf("unknown cache backend: %s", *cacheBackend)
+	}
 
 	pathOrUrl := args[0]
 	var data string

--- a/cli/mesi-cli_test.go
+++ b/cli/mesi-cli_test.go
@@ -201,7 +201,7 @@ func TestCLI_cacheBackendUnknown(t *testing.T) {
 	if err := os.WriteFile(inputFile, []byte("<!--esi Hello-->"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	stdout, stderr, exitCode := runCLI(t, "-cacheBackend=redis", inputFile)
+	stdout, stderr, exitCode := runCLI(t, "-cache-backend=redis", inputFile)
 	if exitCode == 0 {
 		t.Fatalf("expected non-zero exit code for unknown backend, got 0 (stdout=%q stderr=%q)", stdout, stderr)
 	}
@@ -217,23 +217,23 @@ func TestCLI_cacheBackendMemory(t *testing.T) {
 		t.Fatal(err)
 	}
 	stdout, _, exitCode := runCLI(t,
-		"-cacheBackend=memory",
-		"-cacheSize=100",
-		"-cacheTTL=10s",
+		"-cache-backend=memory",
+		"-cache-size=100",
+		"-cache-ttl=10s",
 		inputFile,
 	)
 	if exitCode != 0 {
 		t.Fatalf("unexpected exit code %d", exitCode)
 	}
 	if !strings.Contains(stdout, "Hello") {
-		t.Errorf("expected 'Hello' with -cacheBackend=memory, got %q", stdout)
+		t.Errorf("expected 'Hello' with -cache-backend=memory, got %q", stdout)
 	}
 }
 
 func TestCLI_cacheFlagsInHelp(t *testing.T) {
 	stdout, stderr, _ := runCLI(t, "-h")
 	output := stdout + stderr
-	for _, flag := range []string{"-cacheBackend", "-cacheSize", "-cacheTTL"} {
+	for _, flag := range []string{"-cache-backend", "-cache-size", "-cache-ttl"} {
 		if !strings.Contains(output, flag) {
 			t.Errorf("expected %q in -h output, got stdout=%q stderr=%q", flag, stdout, stderr)
 		}

--- a/cli/mesi-cli_test.go
+++ b/cli/mesi-cli_test.go
@@ -194,3 +194,48 @@ func TestCLI_parseOnHeaderFlag(t *testing.T) {
 		t.Errorf("expected 'Hello' with parse-on-header, got %q", stdout)
 	}
 }
+
+func TestCLI_cacheBackendUnknown(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "input.html")
+	if err := os.WriteFile(inputFile, []byte("<!--esi Hello-->"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, exitCode := runCLI(t, "-cacheBackend=redis", inputFile)
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit code for unknown backend, got 0 (stdout=%q stderr=%q)", stdout, stderr)
+	}
+	if !strings.Contains(stderr, "unknown cache backend") {
+		t.Errorf("expected 'unknown cache backend' in stderr, got %q", stderr)
+	}
+}
+
+func TestCLI_cacheBackendMemory(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "input.html")
+	if err := os.WriteFile(inputFile, []byte("<!--esi Hello-->"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, exitCode := runCLI(t,
+		"-cacheBackend=memory",
+		"-cacheSize=100",
+		"-cacheTTL=10s",
+		inputFile,
+	)
+	if exitCode != 0 {
+		t.Fatalf("unexpected exit code %d", exitCode)
+	}
+	if !strings.Contains(stdout, "Hello") {
+		t.Errorf("expected 'Hello' with -cacheBackend=memory, got %q", stdout)
+	}
+}
+
+func TestCLI_cacheFlagsInHelp(t *testing.T) {
+	stdout, stderr, _ := runCLI(t, "-h")
+	output := stdout + stderr
+	for _, flag := range []string{"-cacheBackend", "-cacheSize", "-cacheTTL"} {
+		if !strings.Contains(output, flag) {
+			t.Errorf("expected %q in -h output, got stdout=%q stderr=%q", flag, stdout, stderr)
+		}
+	}
+}

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -169,13 +169,13 @@ fi
 echo ""
 echo "--- Cache Backend Tests ---"
 
-echo "Test 13: -cacheBackend=memory deduplicates duplicate includes"
+echo "Test 13: -cache-backend=memory deduplicates duplicate includes"
 cat > "$TEST_DIR/dup-includes-cached.html" <<'EOF'
 <esi:include src="count/cache-with-backend"/>
 <esi:include src="count/cache-with-backend"/>
 <esi:include src="count/cache-with-backend"/>
 EOF
-RESULT=$("$CLI_BINARY" -cacheBackend=memory -max-workers=1 -allow-private-ips -default-url "http://127.0.0.1:8080/" "$TEST_DIR/dup-includes-cached.html" 2>/dev/null)
+RESULT=$("$CLI_BINARY" -cache-backend=memory -max-workers=1 -allow-private-ips -default-url "http://127.0.0.1:8080/" "$TEST_DIR/dup-includes-cached.html" 2>/dev/null)
 RESULT_TRIM=$(echo "$RESULT" | tr -d '\n')
 if [ "$RESULT_TRIM" = "111" ]; then
 	pass "Cache dedup: 3 duplicate includes resolved with single origin hit"
@@ -183,7 +183,7 @@ else
 	fail "Cache dedup" "Expected '111', got: $RESULT_TRIM"
 fi
 
-echo "Test 14: no -cacheBackend hits origin for every include"
+echo "Test 14: no -cache-backend hits origin for every include"
 cat > "$TEST_DIR/dup-includes-uncached.html" <<'EOF'
 <esi:include src="count/cache-no-backend"/>
 <esi:include src="count/cache-no-backend"/>
@@ -197,8 +197,8 @@ else
 	fail "No cache" "Expected '123', got: $RESULT_TRIM"
 fi
 
-echo "Test 15: unknown -cacheBackend value exits with error"
-RESULT=$("$CLI_BINARY" -cacheBackend=redis -allow-private-ips "$TEST_DIR/dup-includes-cached.html" 2>&1 || true)
+echo "Test 15: unknown -cache-backend value exits with error"
+RESULT=$("$CLI_BINARY" -cache-backend=redis -allow-private-ips "$TEST_DIR/dup-includes-cached.html" 2>&1 || true)
 if echo "$RESULT" | grep -qi "unknown cache backend"; then
 	pass "Unknown backend rejected"
 else

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -167,9 +167,48 @@ else
 fi
 
 echo ""
+echo "--- Cache Backend Tests ---"
+
+echo "Test 13: -cacheBackend=memory deduplicates duplicate includes"
+cat > "$TEST_DIR/dup-includes-cached.html" <<'EOF'
+<esi:include src="count/cache-with-backend"/>
+<esi:include src="count/cache-with-backend"/>
+<esi:include src="count/cache-with-backend"/>
+EOF
+RESULT=$("$CLI_BINARY" -cacheBackend=memory -max-workers=1 -allow-private-ips -default-url "http://127.0.0.1:8080/" "$TEST_DIR/dup-includes-cached.html" 2>/dev/null)
+RESULT_TRIM=$(echo "$RESULT" | tr -d '\n')
+if [ "$RESULT_TRIM" = "111" ]; then
+	pass "Cache dedup: 3 duplicate includes resolved with single origin hit"
+else
+	fail "Cache dedup" "Expected '111', got: $RESULT_TRIM"
+fi
+
+echo "Test 14: no -cacheBackend hits origin for every include"
+cat > "$TEST_DIR/dup-includes-uncached.html" <<'EOF'
+<esi:include src="count/cache-no-backend"/>
+<esi:include src="count/cache-no-backend"/>
+<esi:include src="count/cache-no-backend"/>
+EOF
+RESULT=$("$CLI_BINARY" -max-workers=1 -allow-private-ips -default-url "http://127.0.0.1:8080/" "$TEST_DIR/dup-includes-uncached.html" 2>/dev/null)
+RESULT_TRIM=$(echo "$RESULT" | tr -d '\n')
+if [ "$RESULT_TRIM" = "123" ]; then
+	pass "No cache: 3 duplicate includes each hit origin"
+else
+	fail "No cache" "Expected '123', got: $RESULT_TRIM"
+fi
+
+echo "Test 15: unknown -cacheBackend value exits with error"
+RESULT=$("$CLI_BINARY" -cacheBackend=redis -allow-private-ips "$TEST_DIR/dup-includes-cached.html" 2>&1 || true)
+if echo "$RESULT" | grep -qi "unknown cache backend"; then
+	pass "Unknown backend rejected"
+else
+	fail "Unknown backend" "Output: $RESULT"
+fi
+
+echo ""
 echo "--- Error Handling ---"
 
-echo "Test 13: Missing argument produces error message"
+echo "Test 16: Missing argument produces error message"
 RESULT=$("$CLI_BINARY" 2>&1 || true)
 if echo "$RESULT" | grep -qi "error\|missing\|usage"; then
 	pass "Missing argument error reported"
@@ -177,7 +216,7 @@ else
 	fail "Missing argument" "Output: $RESULT"
 fi
 
-echo "Test 14: Nonexistent file produces error message"
+echo "Test 17: Nonexistent file produces error message"
 RESULT=$("$CLI_BINARY" "/nonexistent/file.html" 2>&1 || true)
 if echo "$RESULT" | grep -qi "error"; then
 	pass "Nonexistent file error reported"
@@ -185,7 +224,7 @@ else
 	fail "Nonexistent file" "Output: $RESULT"
 fi
 
-echo "Test 15: Bad URL produces error message"
+echo "Test 18: Bad URL produces error message"
 RESULT=$("$CLI_BINARY" "http://127.0.0.1:99999/" 2>&1 || true)
 if echo "$RESULT" | grep -qi "error\|refused\|timeout\|connection"; then
 	pass "Bad URL error reported"

--- a/docs/features.md
+++ b/docs/features.md
@@ -32,7 +32,7 @@ Support status of mESI features across all server integrations.
 | MaxWorkers | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | ParseOnHeader | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
 | Debug mode | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Cache (in-memory) | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Cache (in-memory) | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
 | Cache (Redis) | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | Cache (Memcached) | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | Custom CacheKeyFunc | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |

--- a/examples/cache.html
+++ b/examples/cache.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CLI cache example</title>
+</head>
+<body>
+<h1>CLI cache example</h1>
+<p>The three includes below point to the same URL. With
+<code>-cacheBackend=memory</code>, the first response is cached and reused
+for the remaining two; without the flag, the origin is hit three times.</p>
+<esi:include src="include.txt"/>
+<esi:include src="include.txt"/>
+<esi:include src="include.txt"/>
+</body>
+</html>

--- a/tests/server/main.go
+++ b/tests/server/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 )
 
@@ -52,6 +53,20 @@ func returnString(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(r.PathValue("data")))
 }
 
+var (
+	countersMu sync.Mutex
+	counters   = map[string]int{}
+)
+
+func countHandler(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	countersMu.Lock()
+	counters[name]++
+	n := counters[name]
+	countersMu.Unlock()
+	w.Write([]byte(strconv.Itoa(n)))
+}
+
 func main() {
 	srv := &http.Server{Addr: ":8080"}
 
@@ -62,6 +77,7 @@ func main() {
 	http.HandleFunc("/returnNonEsiHeader", returnEsiNoHeader)
 	http.HandleFunc("/recursive", recursive)
 	http.HandleFunc("/returnString/{data}", returnString)
+	http.HandleFunc("/count/{name}", countHandler)
 
 	if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
 		log.Fatalf("ListenAndServe(): %v", err)


### PR DESCRIPTION
Implements the `memory` cache backend for the CLI (issue #207). Duplicate `<esi:include>` URLs within a single invocation are now served from an LRU cache instead of re-fetching the origin.

## Flags

* `-cacheBackend=memory` — enable the in-memory LRU cache (default: off)
* `-cacheSize=<n>` — max cache entries (default: 10000)
* `-cacheTTL=<duration>` — entry TTL, `0` = no expiry (default: 0)
* `-allow-private-ips` — disable dial-time SSRF blocking (needed for the e2e against the local test server)
* `-max-workers=<n>` — cap concurrent include goroutines (`1` forces sequential processing; required for the cache dedup e2e to be deterministic, since the parser races can mask the cache hit otherwise)

## Tests

* **Unit (cli/mesi-cli_test.go):** unknown backend → non-zero exit + error message; valid `memory` config processes a fixture; new flags appear in `-h`
* **E2E (cli/test.sh):** 3 duplicate `<esi:include>`s with `-cacheBackend=memory` resolve to a single server hit (`111`); without cache, 3 distinct hits (`123`); unknown backend rejected

All 21 e2e tests pass, 20 unit tests pass, 399 mesi package tests pass.

## Docs

* `cli/README.md` — new flags documented; per-invocation scope of the cache noted
* `CHANGELOG.md` — entry under new 0.9.0 section
* `docs/features.md` — Cache (in-memory) row updated from ❌ to ✅ for CLI

## Test server

Adds a `/count/{name}` endpoint to `tests/server/main.go` used by the cache e2e. The handler is purely additive and does not affect any other test suite.

## Verification

```
cd cli && go test -count=1 -v ./...    # 20 passed
cd cli && ./test.sh                     # 21 passed
go test -count=1 ./mesi/...             # 399 passed
```

Closes #207