### PR TITLE
feat(cli): add -cacheBackend redis flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - CLI memory cache backend: `-cache-backend=memory`, `-cache-size`, and `-cache-ttl` flags wire the `mesi.MemoryCache` into CLI invocations so duplicate `<esi:include>` URLs are served from cache within a single run (#207)
+- CLI Redis cache backend: `-cache-backend=redis`, `-cache-redis-addr`, `-cache-redis-password`, and `-cache-redis-db` flags wire the `cache_redis.RedisCache` into CLI invocations, enabling Redis-backed ESI caching from the command line (#212)
 
 ## [0.8.0] - Unreleased
 

--- a/cli/mesi-cli.go
+++ b/cli/mesi-cli.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"fmt"
 	"github.com/crazy-goat/go-mesi/mesi"
+	"github.com/crazy-goat/go-mesi/mesi/cache_redis"
+	"github.com/redis/go-redis/v9"
 	"io"
 	"log"
 	"net/http"
@@ -24,11 +26,17 @@ func main() {
 	parseOnHeader := flag.Bool("parse-on-header", false, "Enable parsing on header")
 	debug := flag.Bool("debug", false, "Enable debug logging")
 	cacheBackend := flag.String("cache-backend", "",
-		"Cache backend for ESI includes: memory (default: off)")
+		"Cache backend for ESI includes: memory, redis (default: off)")
 	cacheSize := flag.Int("cache-size", 10000,
 		"Max cache entries for memory backend")
 	cacheTTL := flag.Duration("cache-ttl", 0,
 		"Cache TTL (e.g. 30s, 5m); 0 = no expiry")
+	cacheRedisAddr := flag.String("cache-redis-addr", "localhost:6379",
+		"Redis server address (host:port)")
+	cacheRedisPassword := flag.String("cache-redis-password", "",
+		"Redis password")
+	cacheRedisDB := flag.Int("cache-redis-db", 0,
+		"Redis database number")
 	allowPrivateIPs := flag.Bool("allow-private-ips", false,
 		"Allow ESI includes to private/reserved IP ranges (for local testing)")
 	maxWorkers := flag.Int("max-workers", 0,
@@ -56,6 +64,15 @@ func main() {
 	case "":
 	case "memory":
 		config.Cache = mesi.NewMemoryCache(*cacheSize, *cacheTTL)
+		config.CacheTTL = *cacheTTL
+	case "redis":
+		rdb := redis.NewClient(&redis.Options{
+			Addr:     *cacheRedisAddr,
+			Password: *cacheRedisPassword,
+			DB:       *cacheRedisDB,
+		})
+		defer rdb.Close()
+		config.Cache = cache_redis.NewRedisCache(rdb, *cacheTTL)
 		config.CacheTTL = *cacheTTL
 	default:
 		log.Fatalf("unknown cache backend: %s", *cacheBackend)

--- a/cli/mesi-cli_test.go
+++ b/cli/mesi-cli_test.go
@@ -201,12 +201,32 @@ func TestCLI_cacheBackendUnknown(t *testing.T) {
 	if err := os.WriteFile(inputFile, []byte("<!--esi Hello-->"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	stdout, stderr, exitCode := runCLI(t, "-cache-backend=redis", inputFile)
+	stdout, stderr, exitCode := runCLI(t, "-cache-backend=unknown", inputFile)
 	if exitCode == 0 {
 		t.Fatalf("expected non-zero exit code for unknown backend, got 0 (stdout=%q stderr=%q)", stdout, stderr)
 	}
 	if !strings.Contains(stderr, "unknown cache backend") {
 		t.Errorf("expected 'unknown cache backend' in stderr, got %q", stderr)
+	}
+}
+
+func TestCLI_cacheBackendRedis(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "input.html")
+	if err := os.WriteFile(inputFile, []byte("<!--esi Hello-->"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, exitCode := runCLI(t,
+		"-cache-backend=redis",
+		"-cache-redis-addr=localhost:6379",
+		"-cache-ttl=10s",
+		inputFile,
+	)
+	if exitCode != 0 {
+		t.Fatalf("unexpected exit code %d (stderr=%q)", exitCode, stderr)
+	}
+	if !strings.Contains(stdout, "Hello") {
+		t.Errorf("expected 'Hello' with -cache-backend=redis, got %q", stdout)
 	}
 }
 
@@ -233,7 +253,7 @@ func TestCLI_cacheBackendMemory(t *testing.T) {
 func TestCLI_cacheFlagsInHelp(t *testing.T) {
 	stdout, stderr, _ := runCLI(t, "-h")
 	output := stdout + stderr
-	for _, flag := range []string{"-cache-backend", "-cache-size", "-cache-ttl"} {
+	for _, flag := range []string{"-cache-backend", "-cache-size", "-cache-ttl", "-cache-redis-addr", "-cache-redis-password", "-cache-redis-db"} {
 		if !strings.Contains(output, flag) {
 			t.Errorf("expected %q in -h output, got stdout=%q stderr=%q", flag, stdout, stderr)
 		}

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -198,7 +198,7 @@ else
 fi
 
 echo "Test 15: unknown -cache-backend value exits with error"
-RESULT=$("$CLI_BINARY" -cache-backend=redis -allow-private-ips "$TEST_DIR/dup-includes-cached.html" 2>&1 || true)
+RESULT=$("$CLI_BINARY" -cache-backend=unknown -allow-private-ips "$TEST_DIR/dup-includes-cached.html" 2>&1 || true)
 if echo "$RESULT" | grep -qi "unknown cache backend"; then
 	pass "Unknown backend rejected"
 else

--- a/docs/features.md
+++ b/docs/features.md
@@ -33,7 +33,7 @@ Support status of mESI features across all server integrations.
 | ParseOnHeader | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
 | Debug mode | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
 | Cache (in-memory) | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Cache (Redis) | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Cache (Redis) | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
 | Cache (Memcached) | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | Custom CacheKeyFunc | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | Recursive ESI processing | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |


### PR DESCRIPTION
Closes #212

## Changes

- Added `-cache-redis-addr`, `-cache-redis-password`, and `-cache-redis-db` flags
- Added `case "redis"` handler in the cache backend switch
- Updated help text for `-cache-backend` to mention redis
- Updated feature matrix in `docs/features.md` (CLI Redis: ❌ → ✅)
- Updated `CHANGELOG.md`

## Usage

```bash
mesi-cli -cache-backend=redis -cache-ttl=30s -cache-redis-addr=localhost:6379 -url https://example.com/
```

## Verification

- [x] `go vet` passes
- [x] `go test ./cli/` — 24 tests pass (3 cache backend tests)
- [x] `go test ./...` — 412 tests pass across all 8 packages