### PR TITLE
feat(cli): add -cacheBackend memcached flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - CLI memory cache backend: `-cache-backend=memory`, `-cache-size`, and `-cache-ttl` flags wire the `mesi.MemoryCache` into CLI invocations so duplicate `<esi:include>` URLs are served from cache within a single run (#207)
 - CLI Redis cache backend: `-cache-backend=redis`, `-cache-redis-addr`, `-cache-redis-password`, and `-cache-redis-db` flags wire the `cache_redis.RedisCache` into CLI invocations, enabling Redis-backed ESI caching from the command line (#212)
+- CLI Memcached cache backend: `-cache-backend=memcached` and `-cache-memcached-servers` flags wire the `cache_memcached.MemcachedCache` into CLI invocations, enabling Memcached-backed ESI caching from the command line (#217)
 
 ## [0.8.0] - Unreleased
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -50,7 +50,7 @@ mesi-cli [options] path/url
 - **max-depth <depth>** (integer): Defines the maximum depth of parsing, which can limit how many nested ESI includes or references are processed. Default: 5
 - **timeout <seconds>** (float): Sets the request timeout duration (in seconds) for all retrieval operations. Default: 10.0
 - **parse-on-header** (bool): Enables ESI parsing on the HTTP headers, if set to `true` response must have `Edge-control: dca=esi` to enable parsing. Default: false
-- **cache-backend <name>** (string): Cache backend for ESI includes. Currently only `memory` is supported (in-process LRU). Default: off (no caching)
+- **cache-backend <name>** (string): Cache backend for ESI includes. Values: `memory`, `redis`, `memcached`. Default: off (no caching)
 - **cache-size <entries>** (int): Max cache entries for the memory backend. Default: 10000
 - **cache-ttl <duration>** (duration): Cache TTL (e.g. `30s`, `5m`); `0` = no expiry. Default: 0
 - **max-workers <count>** (int): Max concurrent ESI include goroutines. `0` = `NumCPU*4`. Useful for forcing sequential processing to make caching deterministic. Default: 0
@@ -58,13 +58,20 @@ mesi-cli [options] path/url
 
 ### Caching
 
-The CLI exposes the in-memory cache from the `mesi` package. Repeated `<esi:include>` URLs within a single invocation are served from the cache instead of hitting the origin again.
+The CLI exposes the in-memory, Redis, and Memcached caches from the `mesi` package. Repeated `<esi:include>` URLs within a single invocation are served from the cache instead of hitting the origin again.
 
 ```shell
+# In-memory cache (per-invocation)
 mesi-cli -cache-backend=memory -cache-size=5000 -cache-ttl=60s ./input.html
+
+# Redis cache (persistent, shared)
+mesi-cli -cache-backend=redis -cache-ttl=60s -cache-redis-addr=localhost:6379 ./input.html
+
+# Memcached cache (persistent, shared)
+mesi-cli -cache-backend=memcached -cache-ttl=60s -cache-memcached-servers=localhost:11211 ./input.html
 ```
 
-The cache is **per-invocation** — it lives for the duration of a single `mesi-cli` run. For persistent or cross-process caching, run multiple inputs through the same invocation or use one of the server integrations (Traefik, Caddy, etc.) that supports Redis or Memcached.
+The memory cache is **per-invocation** — it lives for the duration of a single `mesi-cli` run. Redis and Memcached caches are persistent and can be shared across invocations.
 
 ## Example Usage
 Render an ESI-enabled HTML from a file:

--- a/cli/mesi-cli.go
+++ b/cli/mesi-cli.go
@@ -3,7 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/crazy-goat/go-mesi/mesi"
+	"github.com/crazy-goat/go-mesi/mesi/cache_memcached"
 	"github.com/crazy-goat/go-mesi/mesi/cache_redis"
 	"github.com/redis/go-redis/v9"
 	"io"
@@ -26,7 +28,7 @@ func main() {
 	parseOnHeader := flag.Bool("parse-on-header", false, "Enable parsing on header")
 	debug := flag.Bool("debug", false, "Enable debug logging")
 	cacheBackend := flag.String("cache-backend", "",
-		"Cache backend for ESI includes: memory, redis (default: off)")
+		"Cache backend for ESI includes: memory, redis, memcached (default: off)")
 	cacheSize := flag.Int("cache-size", 10000,
 		"Max cache entries for memory backend")
 	cacheTTL := flag.Duration("cache-ttl", 0,
@@ -37,6 +39,8 @@ func main() {
 		"Redis password")
 	cacheRedisDB := flag.Int("cache-redis-db", 0,
 		"Redis database number")
+	cacheMemcachedServers := flag.String("cache-memcached-servers", "",
+		"Comma-separated Memcached servers (host:port)")
 	allowPrivateIPs := flag.Bool("allow-private-ips", false,
 		"Allow ESI includes to private/reserved IP ranges (for local testing)")
 	maxWorkers := flag.Int("max-workers", 0,
@@ -73,6 +77,14 @@ func main() {
 		})
 		defer rdb.Close()
 		config.Cache = cache_redis.NewRedisCache(rdb, *cacheTTL)
+		config.CacheTTL = *cacheTTL
+	case "memcached":
+		servers := strings.Split(*cacheMemcachedServers, ",")
+		if *cacheMemcachedServers == "" || len(servers) == 0 || servers[0] == "" {
+			log.Fatal("cache-memcached-servers required for memcached backend")
+		}
+		mc := memcache.New(servers...)
+		config.Cache = cache_memcached.NewMemcachedCache(mc, *cacheTTL)
 		config.CacheTTL = *cacheTTL
 	default:
 		log.Fatalf("unknown cache backend: %s", *cacheBackend)

--- a/cli/mesi-cli_test.go
+++ b/cli/mesi-cli_test.go
@@ -250,10 +250,69 @@ func TestCLI_cacheBackendMemory(t *testing.T) {
 	}
 }
 
+func TestCLI_cacheBackendMemcached(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "input.html")
+	if err := os.WriteFile(inputFile, []byte("<!--esi Hello-->"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, exitCode := runCLI(t,
+		"-cache-backend=memcached",
+		"-cache-memcached-servers=localhost:11211",
+		"-cache-ttl=10s",
+		inputFile,
+	)
+	if exitCode != 0 {
+		t.Fatalf("unexpected exit code %d (stderr=%q)", exitCode, stderr)
+	}
+	if !strings.Contains(stdout, "Hello") {
+		t.Errorf("expected 'Hello' with -cache-backend=memcached, got %q", stdout)
+	}
+}
+
+func TestCLI_cacheBackendMemcachedNoServers(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "input.html")
+	if err := os.WriteFile(inputFile, []byte("<!--esi Hello-->"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, stderr, exitCode := runCLI(t,
+		"-cache-backend=memcached",
+		"-cache-ttl=10s",
+		inputFile,
+	)
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit code for memcached without servers, got 0")
+	}
+	if !strings.Contains(stderr, "cache-memcached-servers required") {
+		t.Errorf("expected 'cache-memcached-servers required' in stderr, got %q", stderr)
+	}
+}
+
+func TestCLI_cacheBackendMemcachedEmptyServers(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "input.html")
+	if err := os.WriteFile(inputFile, []byte("<!--esi Hello-->"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, stderr, exitCode := runCLI(t,
+		"-cache-backend=memcached",
+		"-cache-memcached-servers=",
+		"-cache-ttl=10s",
+		inputFile,
+	)
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit code for empty servers, got 0")
+	}
+	if !strings.Contains(stderr, "cache-memcached-servers required") {
+		t.Errorf("expected 'cache-memcached-servers required' in stderr, got %q", stderr)
+	}
+}
+
 func TestCLI_cacheFlagsInHelp(t *testing.T) {
 	stdout, stderr, _ := runCLI(t, "-h")
 	output := stdout + stderr
-	for _, flag := range []string{"-cache-backend", "-cache-size", "-cache-ttl", "-cache-redis-addr", "-cache-redis-password", "-cache-redis-db"} {
+	for _, flag := range []string{"-cache-backend", "-cache-size", "-cache-ttl", "-cache-redis-addr", "-cache-redis-password", "-cache-redis-db", "-cache-memcached-servers"} {
 		if !strings.Contains(output, flag) {
 			t.Errorf("expected %q in -h output, got stdout=%q stderr=%q", flag, stdout, stderr)
 		}

--- a/docs/features.md
+++ b/docs/features.md
@@ -34,7 +34,7 @@ Support status of mESI features across all server integrations.
 | Debug mode | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
 | Cache (in-memory) | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
 | Cache (Redis) | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Cache (Memcached) | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Cache (Memcached) | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
 | Custom CacheKeyFunc | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | Recursive ESI processing | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Shared HTTPClient | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |

--- a/examples/cache.html
+++ b/examples/cache.html
@@ -6,7 +6,8 @@
 <body>
 <h1>CLI cache example</h1>
 <p>The three includes below point to the same URL. With
-<code>-cacheBackend=memory</code>, the first response is cached and reused
+<code>-cacheBackend=memory</code>, <code>-cacheBackend=redis</code>, or
+<code>-cacheBackend=memcached</code>, the first response is cached and reused
 for the remaining two; without the flag, the origin is hit three times.</p>
 <esi:include src="include.txt"/>
 <esi:include src="include.txt"/>


### PR DESCRIPTION
Closes #217

## Changes

- Added `-cache-memcached-servers` flag (comma-separated host:port list)
- Added `case "memcached"` handler in the cache backend switch
- Updated help text for `-cache-backend` to mention memcached
- Updated feature matrix in `docs/features.md` (CLI Memcached: ❌ → ✅)
- Updated `CHANGELOG.md`
- Updated CLI README with memcached usage examples

## Usage

```bash
mesi-cli -cache-backend=memcached -cache-ttl=120s -cache-memcached-servers=localhost:11211 -url https://example.com/
```

## Verification

- [x] `go vet` passes
- [x] `go test ./cli/` — 23 tests pass (including 2 new memcached error tests)
- [x] `go test ./mesi/...` — 399 tests pass across 3 packages
