### PR TITLE
fix(mesi): reject malformed ab-ratio instead of silently substituting 50:50 (#315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 - CLI Memcached cache backend: `-cache-backend=memcached` and `-cache-memcached-servers` flags wire the `cache_memcached.MemcachedCache` into CLI invocations, enabling Memcached-backed ESI caching from the command line (#217)
 - RoadRunner Memcached cache backend: `cache_backend: memcached` and `cache_memcached_servers` config option wire the `cache_memcached.MemcachedCache` into the RoadRunner middleware, enabling Memcached-backed ESI caching (#245)
 
+### Changed
+- **`<esi:include fetch-mode="ab" ab-ratio="…">` now rejects malformed input.** Previously the parser silently substituted the documented `{A:50, B:50}` default for every malformed value (missing colon, extra colons, negative numbers, decimals, non-integer operands, oversized integers, both-sides-zero). It now returns `*ErrInvalidABRatio` through the existing include-error path, surfacing the operator's actual input in logs and the `IncludeErrorMarker` (#315).
+
+### Fixed
+- `selectUrl` integer-sum overflow at high ratios guarded against `math.MaxInt` saturation (#315).
+
 ## [0.8.0] - Unreleased
 
 ### Added

--- a/docs/features.md
+++ b/docs/features.md
@@ -59,3 +59,9 @@ Support status of mESI features across all server integrations.
 - **Caddy / FrankenPHP** – FrankenPHP uses the Caddy plugin, identical functionality.
 - **Proxy** – Accepts full `EsiParserConfig`; all features available when provided by calling code.
 - **IncludeErrorMarker (CLI)** – Can only be set programmatically (no CLI flag).
+- **`fetch-mode="ab"` (`ab-ratio`)** – Format requirements enforced since #315:
+  - Exactly one `:` separator (`A:B`); leading and trailing whitespace is trimmed.
+  - Each side must be a non-negative unsigned integer.
+  - Either side may be zero; both zero (`0:0`) is rejected because no traffic would reach `Alt`.
+  - Each side must be ≤ `MaxABRatio` (1,000,000) — protects downstream arithmetic from silent overflow.
+  - Malformed values (missing colon, extra colons, non-numeric, negative, decimal, oversized, both-zero) yield `*ErrInvalidABRatio`. The error surfaces through the existing include-error path: rendered as `IncludeErrorMarker` (empty by default), skipped if `onerror="continue"`, or replaced with the tag body if provided. Empty `ab-ratio` falls back to the documented default `50:50`.

--- a/mesi/ab_ratio.go
+++ b/mesi/ab_ratio.go
@@ -1,53 +1,136 @@
 package mesi
 
 import (
+	"fmt"
 	// NOTE: math/rand is used instead of math/rand/v2 for Traefik plugin
 	// compatibility. Yaegi (Traefik's Go interpreter) does not support
 	// packages introduced in Go 1.22+ like math/rand/v2.
 	// See: https://github.com/traefik/yaegi/issues/1674
+	"math"
 	"math/rand"
 	"strconv"
 	"strings"
 )
 
-type abRatio struct {
-	A uint
-	B uint
+// MaxABRatio is the documented upper bound for either side of an
+// `<esi:include ab-ratio="A:B">` value. It is intentionally generous — well
+// above any realistic A/B-test traffic split — but small enough to make
+// downstream arithmetic safe on every Go target platform (A+B <= 2*MaxABRatio
+// fits comfortably in any int, including int32).
+//
+// Rejecting values outside [0, MaxABRatio] surfaces operator mistakes
+// (typos, units confusion) instead of silently rebalancing to 50:50.
+const MaxABRatio uint64 = 1_000_000
+
+// ErrInvalidABRatio is the sentinel for any malformed `ab-ratio` attribute.
+// Callers receive it wrapped with the offending value, so log output shows
+// exactly what the operator set.
+type ErrInvalidABRatio struct {
+	Input string
+	Why   string
 }
 
-func (token *esiIncludeToken) parseAB() abRatio {
-	defaultValue := abRatio{
-		A: 50,
-		B: 50,
+func (e *ErrInvalidABRatio) Error() string {
+	return fmt.Sprintf("invalid ab-ratio %q: %s", e.Input, e.Why)
+}
+
+// abRatio holds the parsed outcome of an `ab-ratio` attribute.
+//
+// Both fields are bounded by [0, MaxABRatio] and at least one of them is
+// non-zero; operations downstream of parseAB rely on those invariants.
+type abRatio struct {
+	A uint64
+	B uint64
+}
+
+// parseAB turns the raw `ab-ratio` attribute into a validated abRatio.
+//
+// An empty attribute is treated as "operator did not set a ratio" and
+// returns the documented default of {A:50, B:50} with a nil error.
+// Any present-but-malformed attribute returns an *ErrInvalidABRatio
+// describing what went wrong; callers surface it as an include error so
+// the operator actually sees it.
+func (token *esiIncludeToken) parseAB() (abRatio, error) {
+	const defaultA uint64 = 50
+	const defaultB uint64 = 50
+
+	if token.ABRatio == "" {
+		return abRatio{A: defaultA, B: defaultB}, nil
 	}
 
-	if !strings.Contains(token.ABRatio, ":") {
-		return defaultValue
+	raw := strings.TrimSpace(token.ABRatio)
+
+	// An attribute that is set but contains only whitespace is treated the
+	// same as an unset attribute: the operator hasn't supplied a ratio, so
+	// we fall back to the documented default. Anything beyond whitespace
+	// is treated as a deliberate attempt to set a ratio and must validate.
+	if raw == "" {
+		return abRatio{A: defaultA, B: defaultB}, nil
 	}
 
-	parts := strings.Split(token.ABRatio, ":")
+	if !strings.Contains(raw, ":") {
+		return abRatio{}, &ErrInvalidABRatio{
+			Input: token.ABRatio,
+			Why:   "missing ':' separator",
+		}
+	}
+
+	parts := strings.Split(raw, ":")
 	if len(parts) != 2 {
-		return defaultValue
+		return abRatio{}, &ErrInvalidABRatio{
+			Input: token.ABRatio,
+			Why:   fmt.Sprintf("expected exactly 2 parts, got %d", len(parts)),
+		}
 	}
 
-	a, err := strconv.ParseUint(parts[0], 10, 64)
+	a, err := parseABSide(parts[0])
 	if err != nil {
-		return defaultValue
+		return abRatio{}, &ErrInvalidABRatio{
+			Input: token.ABRatio,
+			Why:   fmt.Sprintf("A side: %s", err.Error()),
+		}
 	}
 
-	b, err := strconv.ParseUint(parts[1], 10, 64)
+	b, err := parseABSide(parts[1])
 	if err != nil {
-		return defaultValue
+		return abRatio{}, &ErrInvalidABRatio{
+			Input: token.ABRatio,
+			Why:   fmt.Sprintf("B side: %s", err.Error()),
+		}
 	}
 
 	if a == 0 && b == 0 {
-		return defaultValue
+		return abRatio{}, &ErrInvalidABRatio{
+			Input: token.ABRatio,
+			Why:   "both sides are zero (no traffic would ever reach B)",
+		}
 	}
 
-	return abRatio{
-		A: uint(a),
-		B: uint(b),
+	return abRatio{A: a, B: b}, nil
+}
+
+// parseABSide validates one half of the `A:B` ratio. Negative and decimal
+// inputs are rejected explicitly (ParseUint on "-5" fails with a
+// confusing "invalid syntax" message); we surface a clean error.
+func parseABSide(side string) (uint64, error) {
+	side = strings.TrimSpace(side)
+	if side == "" {
+		return 0, fmt.Errorf("empty value")
 	}
+	if strings.HasPrefix(side, "-") {
+		return 0, fmt.Errorf("negative value %q", side)
+	}
+	if strings.Contains(side, ".") {
+		return 0, fmt.Errorf("non-integer value %q", side)
+	}
+	n, err := strconv.ParseUint(side, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("not an unsigned integer (got %q)", side)
+	}
+	if n > MaxABRatio {
+		return 0, fmt.Errorf("value %d exceeds maximum %d", n, MaxABRatio)
+	}
+	return n, nil
 }
 
 func (ratio abRatio) selectUrl(token *esiIncludeToken, rng func(int) int) string {
@@ -57,8 +140,14 @@ func (ratio abRatio) selectUrl(token *esiIncludeToken, rng func(int) int) string
 
 	sum := ratio.A + ratio.B
 
+	// sum is bounded by 2*MaxABRatio (2_000_000), well inside any int.
+	// The overflow guard documents the invariant for future maintainers
+	// who raise MaxABRatio past math.MaxInt32 / math.MaxInt64.
 	if sum == 0 {
 		return token.Src
+	}
+	if sum > math.MaxInt {
+		return token.Alt
 	}
 
 	if rng == nil {
@@ -75,7 +164,12 @@ func (ratio abRatio) selectUrl(token *esiIncludeToken, rng func(int) int) string
 
 func fetchAB(token *esiIncludeToken, config EsiParserConfig) (string, bool, error) {
 	logger := config.getLogger()
-	selected := token.parseAB().selectUrl(token, nil)
+	ratio, err := token.parseAB()
+	if err != nil {
+		logger.Debug("ab_ratio_invalid", "src", token.Src, "ab_ratio", token.ABRatio, "error", err.Error())
+		return "", false, err
+	}
+	selected := ratio.selectUrl(token, nil)
 	logger.Debug("ab_ratio_select", "src", token.Src, "alt", token.Alt, "selected", selected)
 	return singleFetchUrlWithContext(selected, config, config.Context)
 }

--- a/mesi/ab_ratio_test.go
+++ b/mesi/ab_ratio_test.go
@@ -1,38 +1,34 @@
 package mesi
 
 import (
+	"errors"
+	"strings"
 	"testing"
 )
 
 func TestParseABValidRatio(t *testing.T) {
-	token := &esiIncludeToken{ABRatio: "70:30"}
-	ratio := token.parseAB()
-	if ratio.A != 70 {
-		t.Errorf("A = %d, want 70", ratio.A)
-	}
-	if ratio.B != 30 {
-		t.Errorf("B = %d, want 30", ratio.B)
-	}
-}
-
-func TestParseABInvalidRatioDefaults(t *testing.T) {
 	cases := []struct {
-		name  string
-		ratio string
-		wantA uint
-		wantB uint
+		name   string
+		ratio  string
+		wantA  uint64
+		wantB  uint64
 	}{
-		{"missing colon", "7030", 50, 50},
-		{"too many parts", "70:30:10", 50, 50},
-		{"non-numeric", "abc:def", 50, 50},
-		{"empty string", "", 50, 50},
-		{"both zero", "0:0", 50, 50},
+		{"typical 70:30", "70:30", 70, 30},
+		{"trivial 50:50", "50:50", 50, 50},
+		{"asymmetric 0:100", "0:100", 0, 100},
+		{"asymmetric 100:0", "100:0", 100, 0},
+		{"with surrounding whitespace", "  90:10  ", 90, 10},
+		{"single side allowed at max", "0:1000000", 0, 1_000_000},
+		{"single side allowed at max swapped", "1000000:0", 1_000_000, 0},
+		{"both at max", "1000000:1000000", 1_000_000, 1_000_000},
 	}
-
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			token := &esiIncludeToken{ABRatio: tc.ratio}
-			ratio := token.parseAB()
+			ratio, err := token.parseAB()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if ratio.A != tc.wantA {
 				t.Errorf("A = %d, want %d", ratio.A, tc.wantA)
 			}
@@ -43,13 +39,108 @@ func TestParseABInvalidRatioDefaults(t *testing.T) {
 	}
 }
 
+func TestParseABEmptyDefaultsTo5050(t *testing.T) {
+	token := &esiIncludeToken{ABRatio: ""}
+	ratio, err := token.parseAB()
+	if err != nil {
+		t.Fatalf("empty ratio should default to 50:50 without error, got: %v", err)
+	}
+	if ratio.A != 50 || ratio.B != 50 {
+		t.Errorf("default = (%d,%d), want (50,50)", ratio.A, ratio.B)
+	}
+}
+
+func TestParseABWhitespaceOnlyDefaultsTo5050(t *testing.T) {
+	token := &esiIncludeToken{ABRatio: "   "}
+	ratio, err := token.parseAB()
+	if err != nil {
+		t.Fatalf("whitespace-only ratio should default to 50:50 without error, got: %v", err)
+	}
+	if ratio.A != 50 || ratio.B != 50 {
+		t.Errorf("default = (%d,%d), want (50,50)", ratio.A, ratio.B)
+	}
+}
+
+func TestParseABRejectsInvalidRatio(t *testing.T) {
+	cases := []struct {
+		name            string
+		ratio           string
+		wantMsgContains string
+	}{
+		{"missing colon", "7030", "':' separator"},
+		{"too many parts", "70:30:10", "got 3"},
+		{"non-numeric A", "abc:def", "A side"},
+		{"non-numeric B", "70:abc", "B side"},
+		{"both zero", "0:0", "no traffic"},
+		{"decimal A", "70.5:29.5", "non-integer"},
+		{"decimal B", "70:29.5", "non-integer"},
+		{"negative A", "-5:10", "negative"},
+		{"negative B", "5:-10", "negative"},
+		// MaxUint64 (a valid unsigned integer) is rejected by the value-bounds
+		// check because it exceeds MaxABRatio. The point of this case is
+		// "a face-plausible number that doesn't fit our policy is refused".
+		{"uint64 overflow", "18446744073709551615:1", "exceeds maximum"},
+		{"A above max", "1000001:1", "exceeds maximum"},
+		{"B above max", "1:1000001", "exceeds maximum"},
+		{"empty A side", ":50", "empty value"},
+		{"empty B side", "50:", "empty value"},
+		{"untrimmed negative", "-1 : 2", "negative"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			token := &esiIncludeToken{ABRatio: tc.ratio}
+			_, err := token.parseAB()
+			if err == nil {
+				t.Fatalf("expected error for input %q, got nil (silent fallback to default)", tc.ratio)
+			}
+			var ierr *ErrInvalidABRatio
+			if !errors.As(err, &ierr) {
+				t.Fatalf("error type = %T, want *ErrInvalidABRatio", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantMsgContains) {
+				t.Errorf("error message %q does not contain %q", err.Error(), tc.wantMsgContains)
+			}
+			if ierr.Input != tc.ratio {
+				t.Errorf("ErrInvalidABRatio.Input = %q, want %q (operator must see what they typed)", ierr.Input, tc.ratio)
+			}
+		})
+	}
+}
+
+func TestParseABBoundaryValuesTakeExactlyMaxPlusOne(t *testing.T) {
+	// Accepted: MaxABRatio on both sides
+	{
+		token := &esiIncludeToken{ABRatio: "1000000:1000000"}
+		ratio, err := token.parseAB()
+		if err != nil {
+			t.Fatalf("MaxABRatio:MaxABRatio must be accepted, got: %v", err)
+		}
+		if ratio.A != MaxABRatio || ratio.B != MaxABRatio {
+			t.Errorf("got (%d,%d), want (%d,%d)", ratio.A, ratio.B, MaxABRatio, MaxABRatio)
+		}
+	}
+	// Rejected: MaxABRatio+1 on either side
+	{
+		token := &esiIncludeToken{ABRatio: "1000001:1"}
+		if _, err := token.parseAB(); err == nil {
+			t.Error("MaxABRatio+1 must be rejected")
+		}
+	}
+	{
+		token := &esiIncludeToken{ABRatio: "1:1000001"}
+		if _, err := token.parseAB(); err == nil {
+			t.Error("MaxABRatio+1 on B side must be rejected")
+		}
+	}
+}
+
 func TestSelectUrlChoosesBasedOnRatio(t *testing.T) {
 	token := &esiIncludeToken{Src: "/src.html", Alt: "/alt.html"}
 
 	t.Run("rng_in_a_range_selects_src", func(t *testing.T) {
 		ratio := abRatio{A: 80, B: 20}
-		for i := 0; i < 80; i++ {
-			rng := func(int) int { return i }
+		for i := uint64(0); i < 80; i++ {
+			rng := func(int) int { return int(i) }
 			selected := ratio.selectUrl(token, rng)
 			if selected != "/src.html" {
 				t.Errorf("rng=%d: expected src, got %q", i, selected)
@@ -59,8 +150,8 @@ func TestSelectUrlChoosesBasedOnRatio(t *testing.T) {
 
 	t.Run("rng_in_b_range_selects_alt", func(t *testing.T) {
 		ratio := abRatio{A: 80, B: 20}
-		for i := 80; i < 100; i++ {
-			rng := func(int) int { return i }
+		for i := uint64(80); i < 100; i++ {
+			rng := func(int) int { return int(i) }
 			selected := ratio.selectUrl(token, rng)
 			if selected != "/alt.html" {
 				t.Errorf("rng=%d: expected alt, got %q", i, selected)
@@ -88,6 +179,15 @@ func TestSelectUrlChoosesBasedOnRatio(t *testing.T) {
 			if selected != "/src.html" {
 				t.Errorf("rng=%d: expected src when sum=0, got %q", v, selected)
 			}
+		}
+	})
+
+	t.Run("max_sum_a_saturating_rng_returns_src", func(t *testing.T) {
+		ratio := abRatio{A: MaxABRatio, B: 0}
+		// A path always picks Src regardless of rng
+		selected := ratio.selectUrl(token, func(int) int { return int(MaxABRatio) - 1 })
+		if selected != "/src.html" {
+			t.Errorf("expected src when A=MaxABRatio, got %q", selected)
 		}
 	})
 }

--- a/mesi/parser_test.go
+++ b/mesi/parser_test.go
@@ -1599,3 +1599,100 @@ func TestESITryE2EFixture(t *testing.T) {
 }
 
 
+func TestMESIParseABRatioRejectsInvalidInput(t *testing.T) {
+	// The mock upstream must never be touched when the ab-ratio attribute
+	// fails validation. We count requests; any non-zero count indicates
+	// the legacy "silent default" behaviour leaked back in.
+	var upstreamHits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("UPSTREAM"))
+	}))
+	defer server.Close()
+
+	config := CreateDefaultConfig()
+	config.DefaultUrl = server.URL + "/"
+	config.MaxDepth = 1
+	config.BlockPrivateIPs = false
+	config.IncludeErrorMarker = "[ERR]"
+
+	cases := []struct {
+		name        string
+		abRatio     string
+		wantErrMark bool
+		wantContent string // substring inside [ERR] when err-mark path is taken
+	}{
+		{"missing colon", "7030", true, "[ERR]"},
+		{"too many parts", "70:30:10", true, "[ERR]"},
+		{"both zero", "0:0", true, "[ERR]"},
+		{"negative A", "-5:10", true, "[ERR]"},
+		{"A above max", "1000001:1", true, "[ERR]"},
+		{"decimal value", "70.5:29.5", true, "[ERR]"},
+		{"non-numeric", "abc:def", true, "[ERR]"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			upstreamHits.Store(0)
+			input := `<esi:include fetch-mode="ab" ab-ratio="` + tc.abRatio + `" src="` + server.URL + `/A" alt="` + server.URL + `/B"/>`
+			result := MESIParse(input, config)
+
+			if upstreamHits.Load() != 0 {
+				t.Errorf("upstream fetched %d times despite invalid ab-ratio %q — silent fallback leaked through",
+					upstreamHits.Load(), tc.abRatio)
+			}
+			if tc.wantErrMark && !strings.Contains(result, tc.wantContent) {
+				t.Errorf("expected IncludeErrorMarker %q in result for ab-ratio=%q, got %q", tc.wantContent, tc.abRatio, result)
+			}
+		})
+	}
+}
+
+func TestMESIParseABRatioAcceptedBoundaries(t *testing.T) {
+	// Accepted boundaries must return the upstream body. Boundary at
+	// MaxABRatio is the largest value we promise to honour.
+	cases := []struct {
+		name    string
+		abRatio string
+		want    string
+	}{
+		{"min 0:1", "0:1", "B"},
+		{"min 1:0", "1:0", "A"},
+		{"max 1000000:0", "1000000:0", "A"},
+		{"max 0:1000000", "0:1000000", "B"},
+		{"both at max 1000000:1000000", "1000000:1000000", ""}, // pick is rng-dependent; just verify it returns A or B (not error mark)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tc.want))
+			}))
+			defer server.Close()
+
+			config := CreateDefaultConfig()
+			config.DefaultUrl = server.URL + "/"
+			config.MaxDepth = 1
+			config.BlockPrivateIPs = false
+			config.IncludeErrorMarker = "[ERR]"
+
+			if tc.name == "both at max 1000000:1000000" {
+				// rng-driven; just verify no error mark shows up
+				input := `<esi:include fetch-mode="ab" ab-ratio="` + tc.abRatio + `" src="` + server.URL + `/A" alt="` + server.URL + `/B"/>`
+				result := MESIParse(input, config)
+				if strings.Contains(result, "[ERR]") {
+					t.Errorf("both-at-max should not error, got %q", result)
+				}
+				return
+			}
+
+			input := `<esi:include fetch-mode="ab" ab-ratio="` + tc.abRatio + `" src="` + server.URL + `/A" alt="` + server.URL + `/B"/>`
+			result := MESIParse(input, config)
+			if result != tc.want {
+				t.Errorf("ab-ratio=%q -> %q, want %q", tc.abRatio, result, tc.want)
+			}
+		})
+	}
+}

--- a/tests/fixtures/17-ab-ratio-rejected.html
+++ b/tests/fixtures/17-ab-ratio-rejected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>AB ratio rejection - explicit error path</title>
+</head>
+<body>
+malformed ab-ratio (missing colon): [<esi:include fetch-mode="ab" ab-ratio="7030" src="http://127.0.0.1:8080/returnString/A" alt="http://127.0.0.1:8080/returnString/B" />]
+malformed ab-ratio (too many parts): [<esi:include fetch-mode="ab" ab-ratio="70:30:10" src="http://127.0.0.1:8080/returnString/A" alt="http://127.0.0.1:8080/returnString/B" />]
+malformed ab-ratio (both zero): [<esi:include fetch-mode="ab" ab-ratio="0:0" src="http://127.0.0.1:8080/returnString/A" alt="http://127.0.0.1:8080/returnString/B" />]
+malformed ab-ratio (negative A): [<esi:include fetch-mode="ab" ab-ratio="-5:10" src="http://127.0.0.1:8080/returnString/A" alt="http://127.0.0.1:8080/returnString/B" />]
+malformed ab-ratio (A above max): [<esi:include fetch-mode="ab" ab-ratio="1000001:1" src="http://127.0.0.1:8080/returnString/A" alt="http://127.0.0.1:8080/returnString/B" />]
+malformed ab-ratio (decimal): [<esi:include fetch-mode="ab" ab-ratio="70.5:29.5" src="http://127.0.0.1:8080/returnString/A" alt="http://127.0.0.1:8080/returnString/B" />]
+malformed ab-ratio (non-numeric): [<esi:include fetch-mode="ab" ab-ratio="abc:def" src="http://127.0.0.1:8080/returnString/A" alt="http://127.0.0.1:8080/returnString/B" />]
+</body>
+</html>

--- a/tests/fixtures/17-ab-ratio-rejected.html.expected
+++ b/tests/fixtures/17-ab-ratio-rejected.html.expected
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>AB ratio rejection - explicit error path</title>
+</head>
+<body>
+malformed ab-ratio (missing colon): []
+malformed ab-ratio (too many parts): []
+malformed ab-ratio (both zero): []
+malformed ab-ratio (negative A): []
+malformed ab-ratio (A above max): []
+malformed ab-ratio (decimal): []
+malformed ab-ratio (non-numeric): []
+</body>
+</html>


### PR DESCRIPTION
Fixes #315

The `mesi` package's `<esi:include fetch-mode="ab" ab-ratio="A:B">` parser
deliberately swallows every error and returns a hard-coded default of
`{A:50, B:50}` instead of signalling that the input was rejected. This
fixes that.

## Changes

- **Explicit bounds.** New `MaxABRatio = 1_000_000` constant; values above
  it on either side are rejected. The constant is intentionally large —
  well above any realistic A/B traffic split — but small enough that
  `A+B ≤ 2 * MaxABRatio` is safe on every Go target platform (including
  int32).
- **Explicit error.** `parseAB` now returns `(abRatio, error)`. The new
  sentinel `*ErrInvalidABRatio` carries the offending input verbatim so
  logs and the `IncludeErrorMarker` surface exactly what the operator
  typed.
- **Defensive overflow guard in `selectUrl`** even though the new bounds
  make overflow unreachable; explicit `if sum > math.MaxInt` documents
  the invariant for future maintainers.
- **Empty / whitespace-only `ab-ratio` keeps the documented `50:50`
  default** so callers that simply omit the attribute aren't broken.

## Test coverage

- **Unit tests** (`mesi/ab_ratio_test.go`): accepted boundaries
  (`0:1`, `1:0`, `MaxABRatio:0`, `0:MaxABRatio`, `MaxABRatio:MaxABRatio`,
  surrounding-whitespace); rejected boundaries (missing colon, >2 parts,
  negative A/B, decimal, non-numeric, both-zero, A-above-max, B-above-max,
  empty A or B side, untrimmed negative); `ErrInvalidABRatio` message
  sanity.
- **Integration tests** (`mesi/parser_test.go`):
  - `TestMESIParseABRatioRejectsInvalidInput` — uses `httptest`,
    asserts upstream is never hit and `IncludeErrorMarker` is rendered.
  - `TestMESIParseABRatioAcceptedBoundaries` — asserts both ends of the
    accepted boundary actually return the correct source.
- **E2E fixture** (`tests/fixtures/17-ab-ratio-rejected.html(+.expected)`):
  seven cases of malformed `ab-ratio` produce empty output through the
  existing include-error path.

## Documentation

- `CHANGELOG.md` — Added a `### Changed` entry under `[0.9.0]` and a
  `### Fixed` entry under overflow guard, both referencing #315.
- `docs/features.md` — Added a `fetch-mode="ab" (ab-ratio)` note paragraph
  that documents the new explicit-bounds semantics.

## Backwards compatibility

Empty / whitespace-only `ab-ratio` continues to default to `50:50`
preserving prior behaviour for callers that simply omit the attribute.
Any caller that was relying on **invalid** input silently becoming
`50:50` will now see the include fail with `*ErrInvalidABRatio` — that's
the intended behaviour and is what #315 asks for.

## Local validation

- `go vet ./mesi/...` clean.
- `go test -count=1 -v ./mesi/...` green (all pre-existing tests + new
  tests pass).
- `./scripts/check-no-generated-artifacts.sh` ok.
- `golangci-lint run ./mesi/...` reports 9 pre-existing issues in
  `mesi/logger.go` and `mesi/fetch_test.go`; **zero new issues** from
  this PR.
- E2E: `tests/run-test.sh` — fixture 17 ok; pre-existing fixture
  failures (01–05, 07, 11, 12, 13, 15) are unrelated to this change
  and present on `main`.
