### PR TITLE
feat(cli): add -include-error-marker flag for failed ESI includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.13.0] - Unreleased
 
 ### Added
+- CLI `-include-error-marker` flag: custom marker string rendered for failed ESI includes. When set, failed `<esi:include>` tags (without `onerror="continue"` or fallback body) render the marker in the HTML output instead of producing empty output. Useful for debugging — e.g. `-include-error-marker='<!-- esi error -->'`. Default: "" (silent) (#202)
 - CLI `-shared-http-client` flag: when set, creates a shared `http.Client` with connection pooling and SSRF-safe transport for all ESI includes within a single invocation. Reduces latency for pages with many includes to the same origin (#227)
 - CLI `-cache-key-template` flag: custom cache key template with `${url}` placeholder substitution. Example: `-cache-key-template='myapp:${url}'` (#222)
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -57,6 +57,7 @@ mesi-cli [options] path/url
 - **allow-private-ips** (bool): Allow ESI includes to private/reserved IP ranges. Required when testing against a local ESI origin. Default: false
 - **shared-http-client** (bool): Share a single HTTP client (with connection pooling) across all ESI includes within a single invocation. When false (default), each include creates a fresh `http.Client`. Use this flag when processing a page with many includes to the same origin for measurable latency improvement. Default: false
 - **cache-key-template <template>** (string): Custom cache key template with placeholders. Supported placeholders: `${url}` (the include URL). Example: `mesi:${url}:${header:Accept-Language}`. Note: header and cookie placeholders require an HTTP request context and are not supported in CLI mode (only `${url}` is substituted). Default: URL-only cache key.
+- **include-error-marker <marker>** (string): Marker string rendered in place of a failed `<esi:include>` when no `onerror="continue"` and no fallback body is present. Useful for debugging — set to something like `"<!-- esi error -->"` to make failed includes visible in the rendered HTML. Security warning: never include the original error message as it may leak internal details. Default: "" (silent — failed includes produce empty output).
 
 ### Caching
 

--- a/cli/mesi-cli.go
+++ b/cli/mesi-cli.go
@@ -49,6 +49,8 @@ func main() {
 		"Max concurrent ESI include goroutines (0 = NumCPU*4)")
 	sharedHTTPClient := flag.Bool("shared-http-client", false,
 		"Share HTTP client across ESI includes for connection pooling")
+	includeErrorMarker := flag.String("include-error-marker", "",
+		"Marker string rendered for failed ESI includes (e.g. '<!-- esi error -->')")
 
 	flag.Parse()
 	args := flag.Args()
@@ -67,6 +69,7 @@ func main() {
 	config.Debug = *debug
 	config.BlockPrivateIPs = !*allowPrivateIPs
 	config.MaxWorkers = *maxWorkers
+	config.IncludeErrorMarker = *includeErrorMarker
 
 	if *sharedHTTPClient {
 		config.HTTPClient = &http.Client{

--- a/cli/mesi-cli_test.go
+++ b/cli/mesi-cli_test.go
@@ -435,6 +435,76 @@ func TestCLI_sharedHTTPClientFlagPassthrough(t *testing.T) {
 	}
 }
 
+func TestCLI_includeErrorMarkerFlagInHelp(t *testing.T) {
+	stdout, stderr, _ := runCLI(t, "-h")
+	output := stdout + stderr
+	if !strings.Contains(output, "-include-error-marker") {
+		t.Errorf("expected -include-error-marker in help output, got stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestCLI_includeErrorMarkerFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "input.html")
+	if err := os.WriteFile(inputFile, []byte("<!--esi Hello-->"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, exitCode := runCLI(t, "-include-error-marker", "<!-- esi error -->", inputFile)
+	if exitCode != 0 {
+		t.Fatalf("unexpected exit code %d", exitCode)
+	}
+	if !strings.Contains(stdout, "Hello") {
+		t.Errorf("expected 'Hello' in output, got %q", stdout)
+	}
+}
+
+func TestCLI_includeErrorMarkerFlagDefaultEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "input.html")
+	if err := os.WriteFile(inputFile, []byte("<!--esi Hello-->"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Default should be empty string - no marker rendered
+	stdout, _, exitCode := runCLI(t, inputFile)
+	if exitCode != 0 {
+		t.Fatalf("unexpected exit code %d", exitCode)
+	}
+	if !strings.Contains(stdout, "Hello") {
+		t.Errorf("expected 'Hello' in output, got %q", stdout)
+	}
+}
+
+func TestCLI_includeErrorMarkerFlagEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "input.html")
+	if err := os.WriteFile(inputFile, []byte("<!--esi Hello-->"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Explicit empty string should also work
+	stdout, _, exitCode := runCLI(t, "-include-error-marker=", inputFile)
+	if exitCode != 0 {
+		t.Fatalf("unexpected exit code %d", exitCode)
+	}
+	if !strings.Contains(stdout, "Hello") {
+		t.Errorf("expected 'Hello' in output, got %q", stdout)
+	}
+}
+
+func TestCLI_includeErrorMarkerFlagSpecialChars(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "input.html")
+	if err := os.WriteFile(inputFile, []byte("<!--esi Hello-->"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Test with special characters in the marker
+	stdout, _, exitCode := runCLI(t, "-include-error-marker", "[ESI ERROR]", inputFile)
+	if exitCode != 0 {
+		t.Fatalf("unexpected exit code %d", exitCode)
+	}
+	if !strings.Contains(stdout, "Hello") {
+		t.Errorf("expected 'Hello' in output, got %q", stdout)
+	}
+}
 func TestCLI_sharedHTTPClientFlagFalseByDefault(t *testing.T) {
 	// When -shared-http-client is not provided, config.HTTPClient is nil
 	// (per-request clients). This test verifies that the CLI works


### PR DESCRIPTION
Closes #202

## Summary
Adds `-include-error-marker` flag to the CLI. When set, failed `<esi:include>` tags (without `onerror="continue"` or fallback body) render the marker string in the HTML output instead of producing empty output.

## Changes
- Add `-include-error-marker` flag to `cli/mesi-cli.go`
- Map flag to `config.IncludeErrorMarker`
- Add unit tests: flag in help, string value, empty value, default, special chars
- Update `cli/README.md` with flag documentation
- Add changelog entry

## Acceptance criteria
- [x] Tests — Unit test: string, empty, default ""
- [x] Docs — Add to README with security warning
- [x] Changelog — Entry